### PR TITLE
Block assertions

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -174,9 +174,11 @@
 - (void)compainAboutInUse {
     NSLog(@"The FMDatabase %@ is currently in use.", self);
     
+# if !NS_BLOCK_ASSERTIONS
     if (crashOnErrors) {
         NSAssert1(false, @"The FMDatabase %@ is currently in use.", self);
     }
+#endif
 }
 
 - (NSString*)lastErrorMessage {
@@ -300,12 +302,14 @@
                 if (logsErrors) {
                     NSLog(@"DB Error: %d \"%@\"", [self lastErrorCode], [self lastErrorMessage]);
                     NSLog(@"DB Query: %@", sql);
+# if !NS_BLOCK_ASSERTIONS
                     if (crashOnErrors) {
 //#if defined(__BIG_ENDIAN__) && !TARGET_IPHONE_SIMULATOR
 //                        asm{ trap };
 //#endif
                         NSAssert2(false, @"DB Error: %d \"%@\"", [self lastErrorCode], [self lastErrorMessage]);
                     }
+#endif
                 }
                 
                 sqlite3_finalize(pStmt);
@@ -432,12 +436,14 @@
                 if (logsErrors) {
                     NSLog(@"DB Error: %d \"%@\"", [self lastErrorCode], [self lastErrorMessage]);
                     NSLog(@"DB Query: %@", sql);
+# if !NS_BLOCK_ASSERTIONS
                     if (crashOnErrors) {
 //#if defined(__BIG_ENDIAN__) && !TARGET_IPHONE_SIMULATOR
 //                        asm{ trap };
 //#endif
                         NSAssert2(false, @"DB Error: %d \"%@\"", [self lastErrorCode], [self lastErrorMessage]);
                     }
+#endif
                 }
                 
                 sqlite3_finalize(pStmt);


### PR DESCRIPTION
 Prevent "if statement has empty body" warnings.

Only execute the assertion macros if NS_BLOCK_ASSERTIONS is not set.
