### PR TITLE
Remove unneeded error NSLog

### DIFF
--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -195,8 +195,6 @@
         return [n intValue];
     }
     
-    NSLog(@"Warning: I could not find the column named '%@'.", columnName);
-    
     return -1;
 }
 


### PR DESCRIPTION
When recreating objects that had been persisted in the database, I check for the existence of certain columns and will conditionally fill in ivars (in some parts of the application it doesn't make sense to JOIN against some tables, and this makes the processing code a little more reusable).

This log statement slows things down, so I removed it and figured someone else might be doing something similar and benefit.

An alternative fix would be to mask all the debug logs like this behind a DEBUG flag define.  Or maybe define a method which allows you to check for the existence of a particular column in your result set.

(Oops... that was quite a bit of typing considering it was a one line change.)
