### PR TITLE
Fix of warning

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -178,7 +178,7 @@
         return NO;
     }
     
-    int rc = sqlite3_rekey(db, [key UTF8String], strlen([key UTF8String]));
+    int rc = sqlite3_rekey(db, [key UTF8String], (int)strlen([key UTF8String]));
     
     if (rc != SQLITE_OK) {
         NSLog(@"error on rekey: %d", rc);
@@ -197,7 +197,7 @@
         return NO;
     }
     
-    int rc = sqlite3_key(db, [key UTF8String], strlen([key UTF8String]));
+    int rc = sqlite3_key(db, [key UTF8String], (int)strlen([key UTF8String]));
     
     return (rc == SQLITE_OK);
 #else


### PR DESCRIPTION
Hello,

I use fmdb with SQLITE_HAS_CODEC set and get annoying type cast warnings. Here is the simple fix.

Thanks
