### PR TITLE
stringForColumnIndex

### DIFF
--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -300,7 +300,7 @@
         return nil;
     }
     
-    return [NSString stringWithUTF8String:c];
+    return [NSString stringWithFormat:@"%s", c];
 }
 
 - (NSString*)stringForColumn:(NSString*)columnName {


### PR DESCRIPTION
Hey I updated stringForColumnIndex to use NSString stringWithFormat instead of stringWithUTF8String, because NSString stringWithUTF8String sometimes returned null for a valid string.
