### PR TITLE
Removed lowercasing of column and table names

### DIFF
--- a/src/FMDatabaseAdditions.m
+++ b/src/FMDatabaseAdditions.m
@@ -58,8 +58,6 @@ return ret;
 
 - (BOOL)tableExists:(NSString*)tableName {
     
-    tableName = [tableName lowercaseString];
-    
     FMResultSet *rs = [self executeQuery:@"select [sql] from sqlite_master where [type] = 'table' and lower(name) = ?", tableName];
     
     //if at least one next exists, table exists
@@ -98,14 +96,11 @@ return ret;
     
     BOOL returnBool = NO;
     
-    tableName  = [tableName lowercaseString];
-    columnName = [columnName lowercaseString];
-    
     FMResultSet *rs = [self getTableSchema:tableName];
     
     //check if column is present in table schema
     while ([rs next]) {
-        if ([[[rs stringForColumn:@"name"] lowercaseString] isEqualToString:columnName]) {
+        if ([[rs stringForColumn:@"name"] isEqualToString:columnName]) {
             returnBool = YES;
             break;
         }

--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -72,7 +72,7 @@
     int columnIdx = 0;
     for (columnIdx = 0; columnIdx < columnCount; columnIdx++) {
         [_columnNameToIndexMap setObject:[NSNumber numberWithInt:columnIdx]
-                                 forKey:[[NSString stringWithUTF8String:sqlite3_column_name([_statement statement], columnIdx)] lowercaseString]];
+                                 forKey:[NSString stringWithUTF8String:sqlite3_column_name([_statement statement], columnIdx)]];
     }
     _columnNamesSetup = YES;
 }
@@ -223,8 +223,6 @@
     if (!_columnNamesSetup) {
         [self setupColumnNames];
     }
-    
-    columnName = [columnName lowercaseString];
     
     NSNumber *n = [_columnNameToIndexMap objectForKey:columnName];
     


### PR DESCRIPTION
The user created the database, let s/him worry about keeping consistency. Running lowercaseString on a column name for every call of objectForColumnName: results in huge auto-release pool buildups, especially over large data sets.

I propose removing the calls to lowercase as unnecessary.

Thanks for your work!
