### PR TITLE
Won't compile with ARC on OS X 10.8 and iOS 6 with dispatch_release

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -12,6 +12,8 @@
     #define FMDBReturnRetained FMDBRetain
 
     #define FMDBRelease(__v) ([__v release]);
+
+	#define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
 #else
     // -fobjc-arc
     #define FMDBAutorelease(__v)
@@ -21,6 +23,26 @@
     #define FMDBReturnRetained(__v) (__v)
 
     #define FMDBRelease(__v)
+
+	#if TARGET_OS_IPHONE
+		// Compiling for iOS
+		#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+			// iOS 6.0 or later
+			#define FMDBDispatchQueueRelease(__v)
+		#else
+			// iOS 5.X or earlier
+			#define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
+		#endif
+	#else
+		// Compiling for Mac OS X
+		#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080     
+			// Mac OS X 10.8 or later
+			#define FMDBDispatchQueueRelease(__v)
+		#else
+			// Mac OS X 10.7 or earlier
+			#define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
+		#endif
+	#endif
 #endif
 
 

--- a/src/FMDatabasePool.m
+++ b/src/FMDatabasePool.m
@@ -49,7 +49,7 @@
     FMDBRelease(_databaseOutPool);
     
     if (_lockQueue) {
-        dispatch_release(_lockQueue);
+        FMDBDispatchQueueRelease(_lockQueue);
         _lockQueue = 0x00;
     }
 #if ! __has_feature(objc_arc)

--- a/src/FMDatabaseQueue.m
+++ b/src/FMDatabaseQueue.m
@@ -59,7 +59,7 @@
     FMDBRelease(_path);
     
     if (_queue) {
-        dispatch_release(_queue);
+        FMDBDispatchQueueRelease(_queue);
         _queue = 0x00;
     }
 #if ! __has_feature(objc_arc)


### PR DESCRIPTION
Under ARC dispatch queues no longer need to be released via dispatch_release and doing so is a compiler error. I've added a macro that will only call dispatch_release if necessary.
