### PR TITLE
Expose a va_list variant to executeQuery and executeUpdate

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -108,11 +108,13 @@
 - (BOOL)executeUpdateWithFormat:(NSString *)format, ...;
 - (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray *)arguments;
 - (BOOL)executeUpdate:(NSString*)sql withParameterDictionary:(NSDictionary *)arguments;
+- (BOOL)executeUpdate:(NSString*)sql withVAList:(va_list)args;
 
 - (FMResultSet *)executeQuery:(NSString*)sql, ...;
 - (FMResultSet *)executeQueryWithFormat:(NSString*)format, ...;
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray *)arguments;
 - (FMResultSet *)executeQuery:(NSString *)sql withParameterDictionary:(NSDictionary *)arguments;
+- (FMResultSet *)executeQuery:(NSString *)sql withVAList:(va_list)args;
 
 - (BOOL)rollback;
 - (BOOL)commit;

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -682,6 +682,10 @@
     return [self executeQuery:sql withArgumentsInArray:arguments orDictionary:nil orVAList:nil];
 }
 
+- (FMResultSet *)executeQuery:(NSString *)sql withVAList:(va_list)args {
+    return [self executeQuery:sql withArgumentsInArray:nil orDictionary:nil orVAList:args];
+}
+
 - (BOOL)executeUpdate:(NSString*)sql error:(NSError**)outErr withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args {
     
     if (![self databaseExists]) {
@@ -909,6 +913,10 @@
 
 - (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray *)arguments {
     return [self executeUpdate:sql error:nil withArgumentsInArray:arguments orDictionary:nil orVAList:nil];
+}
+
+- (BOOL)executeUpdate:(NSString *)sql withVAList:(va_list)args {
+    return [self executeUpdate:sql error:nil withArgumentsInArray:nil orDictionary:nil orVAList:args];
 }
 
 - (BOOL)executeUpdate:(NSString*)sql withParameterDictionary:(NSDictionary *)arguments {


### PR DESCRIPTION
This patch exposes the va_list possibilities of executeQuery and executeUpdate that were already there.

This allows API consumers to write their own methods with a variable number of arguments, which can simplify things in some cases. The specific example from my project goes like this:

``` objc
+ (NSArray *)itemsFromQuery:(NSString *)sql, ... {
    va_list args;
    va_start(args, sql);
    NSArray __block *array;
    FMDatabaseQueue *queue = [[IGAppDelegate delegate] databaseQueue];
    [queue inDatabase:^(FMDatabase *db) {
        FMResultSet *rs = [db executeQuery:sql withVAList:args];
        array = [IGItem itemsFromResultSet:rs];
        [rs close];
    }];
    va_end(args);
    return array;
}

```
