### PR TITLE
params count doesn't matter while updating with dictionary.

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -806,7 +806,7 @@
     }
     
     
-    if (idx != queryCount) {
+    if (idx != queryCount && !dictionaryArgs) {
         NSLog(@"Error: the bind count is not correct for the # of variables (%@) (executeUpdate)", sql);
         sqlite3_finalize(pStmt);
         _isExecutingStatement = NO;


### PR DESCRIPTION
When execute query or update with dictionary, the parameters count doesn't matter if not match.

e.g. 

``` objective-c
// get all properties. this might more/fewer than what the query wants
NSDictionary* parms = [user dictionaryForProperties]; 

// if every column has a value, we don't need the count matched. whatever more or fewer. 
[db executeUpdate:@"UPDATE User SET name = :name, email = :email, desc = :desc, timestamp = :timestamp WHERE key = :key" withParameterDictionary:parms]
```
