### PR TITLE
executeQuery & executeUpdate with va_list as parameter

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -105,11 +105,13 @@
 
 - (BOOL)update:(NSString*)sql withErrorAndBindings:(NSError**)outErr, ...;
 - (BOOL)executeUpdate:(NSString*)sql, ...;
+- (BOOL)executeUpdate:(NSString*)sql withVAList: (va_list)args;
 - (BOOL)executeUpdateWithFormat:(NSString *)format, ...;
 - (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray *)arguments;
 - (BOOL)executeUpdate:(NSString*)sql withParameterDictionary:(NSDictionary *)arguments;
 
 - (FMResultSet *)executeQuery:(NSString*)sql, ...;
+- (FMResultSet *)executeQuery:(NSString*)sql withVAList: (va_list)args;
 - (FMResultSet *)executeQueryWithFormat:(NSString*)format, ...;
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray *)arguments;
 - (FMResultSet *)executeQuery:(NSString *)sql withParameterDictionary:(NSDictionary *)arguments;

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -665,6 +665,12 @@
     return result;
 }
 
+- (FMResultSet *)executeQuery:(NSString*)sql withVAList: (va_list)args {
+    id result = [self executeQuery:sql withArgumentsInArray:nil orDictionary:nil orVAList:args];
+    
+    return result;
+}
+
 - (FMResultSet *)executeQueryWithFormat:(NSString*)format, ... {
     va_list args;
     va_start(args, format);
@@ -905,6 +911,12 @@
     BOOL result = [self executeUpdate:sql error:nil withArgumentsInArray:nil orDictionary:nil orVAList:args];
     
     va_end(args);
+    return result;
+}
+
+- (BOOL)executeUpdate:(NSString*)sql withVAList: (va_list)args {
+    BOOL result = [self executeUpdate:sql error:nil withArgumentsInArray:nil orDictionary:nil orVAList:args];
+    
     return result;
 }
 


### PR DESCRIPTION
In general, if you're writing variadic functions (that is, functions which take a variable number of arguments) in C, you should write two versions of each function: one which takes an ellipsis (...), and one which takes a va_list. This will allow us to call executeQuery & executeUpdate methods from a function which takes an ellipsis (...).
