### PR TITLE
Added hot fix for CREATE INDEX parallel processing issue

### DIFF
--- a/FMError.h
+++ b/FMError.h
@@ -1,0 +1,13 @@
+//
+//  FMError.h
+//  fmdb
+//
+//  Created by Oleksandr Dodatko on 1/10/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface FMError : NSError
+
+@end

--- a/FMError.m
+++ b/FMError.m
@@ -1,0 +1,13 @@
+//
+//  FMError.m
+//  fmdb
+//
+//  Created by Oleksandr Dodatko on 1/10/13.
+//
+//
+
+#import "FMError.h"
+
+@implementation FMError
+
+@end

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7E98261F169F252F00013023 /* FMError.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E98261D169F252F00013023 /* FMError.h */; };
+		7E982620169F252F00013023 /* FMError.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E98261E169F252F00013023 /* FMError.m */; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
 		8DD76F9F0486AA7600D96B5E /* fmdb.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = C6859EA3029092ED04C91782 /* fmdb.1 */; };
 		CC47A00F148581E9002CCDAB /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CC47A00D148581E9002CCDAB /* FMDatabaseQueue.h */; };
@@ -51,6 +53,8 @@
 /* Begin PBXFileReference section */
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32A70AAB03705E1F00C91783 /* fmdb_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fmdb_Prefix.pch; sourceTree = "<group>"; };
+		7E98261D169F252F00013023 /* FMError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FMError.h; sourceTree = "<group>"; };
+		7E98261E169F252F00013023 /* FMError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMError.m; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* fmdb */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fmdb; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6859EA3029092ED04C91782 /* fmdb.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = fmdb.1; sourceTree = "<group>"; };
 		CC47A00D148581E9002CCDAB /* FMDatabaseQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FMDatabaseQueue.h; path = src/FMDatabaseQueue.h; sourceTree = "<group>"; };
@@ -128,6 +132,8 @@
 				CC9E4EB813B31188005F9210 /* FMDatabasePool.m */,
 				32A70AAB03705E1F00C91783 /* fmdb_Prefix.pch */,
 				CCC24EBE0A13E34D00A6D3E3 /* fmdb.m */,
+				7E98261D169F252F00013023 /* FMError.h */,
+				7E98261E169F252F00013023 /* FMError.m */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -171,15 +177,16 @@
 				EE42910912B42FD00088BD94 /* FMResultSet.h in Headers */,
 				CC9E4EBA13B31188005F9210 /* FMDatabasePool.h in Headers */,
 				CC47A00F148581E9002CCDAB /* FMDatabaseQueue.h in Headers */,
+				7E98261F169F252F00013023 /* FMError.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		8DD76F960486AA7600D96B5E /* fmdb */ = {
+		8DD76F960486AA7600D96B5E /* fmdb-demo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "fmdb" */;
+			buildConfigurationList = 1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "fmdb-demo" */;
 			buildPhases = (
 				8DD76F990486AA7600D96B5E /* Sources */,
 				8DD76F9B0486AA7600D96B5E /* Frameworks */,
@@ -189,7 +196,7 @@
 			);
 			dependencies = (
 			);
-			name = fmdb;
+			name = "fmdb-demo";
 			productInstallPath = "$(HOME)/bin";
 			productName = fmdb;
 			productReference = 8DD76FA10486AA7600D96B5E /* fmdb */;
@@ -234,7 +241,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				8DD76F960486AA7600D96B5E /* fmdb */,
+				8DD76F960486AA7600D96B5E /* fmdb-demo */,
 				EE4290EE12B42F870088BD94 /* FMDB */,
 			);
 		};
@@ -263,6 +270,7 @@
 				EE42910A12B42FD20088BD94 /* FMResultSet.m in Sources */,
 				CC9E4EBB13B31188005F9210 /* FMDatabasePool.m in Sources */,
 				CC47A011148581E9002CCDAB /* FMDatabaseQueue.m in Sources */,
+				7E982620169F252F00013023 /* FMError.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -282,9 +290,7 @@
 				GCC_PREFIX_HEADER = fmdb_Prefix.pch;
 				INSTALL_PATH = "$(HOME)/bin";
 				LIBRARY_SEARCH_PATHS = "$(LIBRARY_SEARCH_PATHS)";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = fmdb;
-				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -300,9 +306,7 @@
 				GCC_PREFIX_HEADER = fmdb_Prefix.pch;
 				INSTALL_PATH = "$(HOME)/bin";
 				LIBRARY_SEARCH_PATHS = "$(LIBRARY_SEARCH_PATHS)";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = fmdb;
-				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -310,26 +314,22 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				GCC_C_LANGUAGE_STANDARD = c99;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_MISSING_PARENTHESES = YES;
 				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_SIGN_COMPARE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 			};
 			name = Debug;
 		};
 		1DEB927A08733DD40010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				GCC_C_LANGUAGE_STANDARD = c99;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 			};
 			name = Release;
 		};
@@ -337,10 +337,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = FMDB;
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -348,9 +352,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = FMDB;
+				SDKROOT = iphoneos;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -358,7 +365,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "fmdb" */ = {
+		1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "fmdb-demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DEB927508733DD40010E9CD /* Debug */,

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -2,6 +2,8 @@
 #import "unistd.h"
 #import <objc/runtime.h>
 
+#import "FMError.h"
+
 @interface FMDatabase ()
 
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;
@@ -293,9 +295,9 @@
     NSDictionary* errorMessage_ = [ NSDictionary dictionaryWithObject: message_ 
                                                                forKey: NSLocalizedDescriptionKey];
     
-    return [NSError errorWithDomain:@"FMDatabase" 
-                               code:sqlite3_errcode(_db)
-                           userInfo:errorMessage_];    
+    return [ FMError errorWithDomain:@"FMDatabase"
+                                code:sqlite3_errcode(_db)
+                            userInfo:errorMessage_];
 }
 
 -(NSError*)lastError

--- a/src/FMDatabaseAdditions.m
+++ b/src/FMDatabaseAdditions.m
@@ -8,6 +8,7 @@
 
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"
+#import "FMError.h"
 
 @interface FMDatabase (PrivateStuff)
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;
@@ -139,7 +140,7 @@ return ret;
         else if (rc != SQLITE_OK) {
             validationSucceeded = NO;
             if (error) {
-                *error = [NSError errorWithDomain:NSCocoaErrorDomain 
+                *error = [FMError errorWithDomain: @"FMDatabase"
                                              code:[self lastErrorCode]
                                          userInfo:[NSDictionary dictionaryWithObject:[self lastErrorMessage] 
                                                                               forKey:NSLocalizedDescriptionKey]];


### PR DESCRIPTION
Sometimes we receive "SQLITE_ERROR" instead of "SQLITE_LOCKED" while running several "SQL INSERT" queries in parallel.

This happens while executing a "CREATE INDEX" query right after data has been successfully inserted to the table.

So far indices are built properly after this hack.
