### PR TITLE
Initialize columnNameToIndexMap when accessed by client code

### DIFF
--- a/src/FMResultSet.h
+++ b/src/FMResultSet.h
@@ -22,11 +22,10 @@
     
     NSString            *_query;
     NSMutableDictionary *_columnNameToIndexMap;
-    BOOL                _columnNamesSetup;
 }
 
 @property (atomic, retain) NSString *query;
-@property (atomic, retain) NSMutableDictionary *columnNameToIndexMap;
+@property (readonly) NSMutableDictionary *columnNameToIndexMap;
 @property (atomic, retain) FMStatement *statement;
 
 + (id)resultSetWithStatement:(FMStatement *)statement usingParentDatabase:(FMDatabase*)aDB;

--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -7,14 +7,8 @@
 @end
 
 
-@interface FMResultSet (Private)
-- (NSMutableDictionary *)columnNameToIndexMap;
-- (void)setColumnNameToIndexMap:(NSMutableDictionary *)value;
-@end
-
 @implementation FMResultSet
 @synthesize query=_query;
-@synthesize columnNameToIndexMap=_columnNameToIndexMap;
 @synthesize statement=_statement;
 
 + (id)resultSetWithStatement:(FMStatement *)statement usingParentDatabase:(FMDatabase*)aDB {
@@ -61,20 +55,17 @@
     return sqlite3_column_count([_statement statement]);
 }
 
-- (void)setupColumnNames {
-    
+- (NSMutableDictionary *)columnNameToIndexMap {
     if (!_columnNameToIndexMap) {
-        [self setColumnNameToIndexMap:[NSMutableDictionary dictionary]];
-    }    
-    
-    int columnCount = sqlite3_column_count([_statement statement]);
-    
-    int columnIdx = 0;
-    for (columnIdx = 0; columnIdx < columnCount; columnIdx++) {
-        [_columnNameToIndexMap setObject:[NSNumber numberWithInt:columnIdx]
-                                 forKey:[[NSString stringWithUTF8String:sqlite3_column_name([_statement statement], columnIdx)] lowercaseString]];
+        int columnCount = sqlite3_column_count([_statement statement]);
+        _columnNameToIndexMap = [[NSMutableDictionary alloc] initWithCapacity:columnCount];
+        int columnIdx = 0;
+        for (columnIdx = 0; columnIdx < columnCount; columnIdx++) {
+            [_columnNameToIndexMap setObject:[NSNumber numberWithInt:columnIdx]
+                                      forKey:[[NSString stringWithUTF8String:sqlite3_column_name([_statement statement], columnIdx)] lowercaseString]];
+        }
     }
-    _columnNamesSetup = YES;
+    return _columnNameToIndexMap;
 }
 
 - (void)kvcMagic:(id)object {
@@ -105,11 +96,7 @@
     if (num_cols > 0) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:num_cols];
         
-        if (!_columnNamesSetup) {
-            [self setupColumnNames];
-        }
-        
-        NSEnumerator *columnNames = [_columnNameToIndexMap keyEnumerator];
+        NSEnumerator *columnNames = [self.columnNameToIndexMap keyEnumerator];
         NSString *columnName = nil;
         while ((columnName = [columnNames nextObject])) {
             id objectValue = [self objectForColumnName:columnName];
@@ -219,14 +206,9 @@
 }
 
 - (int)columnIndexForName:(NSString*)columnName {
-    
-    if (!_columnNamesSetup) {
-        [self setupColumnNames];
-    }
-    
     columnName = [columnName lowercaseString];
     
-    NSNumber *n = [_columnNameToIndexMap objectForKey:columnName];
+    NSNumber *n = [self.columnNameToIndexMap objectForKey:columnName];
     
     if (n) {
         return [n intValue];


### PR DESCRIPTION
Lazily create and populate the dictionary when calling `-columnNameToIndexMap` so that it can be used directly before column values have been accessed.  Among other things, this makes it possible to check whether a column exists in a results set (see issue #79).

This does change the property from `(atomic, retain)` to `(readonly)`, so it will break code that sets this property directly instead of modifying the fmdb-provided dictionary.  That seems like a strange use-case to me, but perhaps there's a situation where it is useful that I'm missing.
