### PR TITLE
Nicer handleing of NULL in execute with format.

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -505,7 +505,7 @@
             [cleanedSQL appendString:@"?"];
             [arguments addObject:arg];
         }
-        else if (add == (unichar)'@')
+        else if (add == (unichar)'@' && last == (unichar) '%')
         {
             [cleanedSQL appendFormat:@"NULL"];
         }


### PR DESCRIPTION
When using executeUpdateWithFormat encountered following issue,
%@ replaced by @ for NULL objects and would fail with non descriptive lastErrorMessage.

example 

```
[db executeUpdateWithFormat@"INSERT INTO TEST VALUES(%@)", NULL];
// results in cleanedSQL == "INSERT INTO TEST VALUES(@)"
// fix changes this to cleanedSQL == "INSERT INTO TEST VALUES(NULL)"
```
