### PR TITLE
NSLog data-bytes instead of data-self when traceExecution=YES.

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -626,7 +626,12 @@
             }
             
             if (_traceExecution) {
-                NSLog(@"obj: %@", obj);
+                if ([obj isKindOfClass:[NSData class]]) {
+                    NSLog(@"data: %d byte", [(NSData*)obj length]);
+                }
+                else {
+                    NSLog(@"obj: %@", obj);
+                }
             }
             
             idx++;
@@ -811,7 +816,12 @@
             }
             
             if (_traceExecution) {
-                NSLog(@"obj: %@", obj);
+                if ([obj isKindOfClass:[NSData class]]) {
+                    NSLog(@"data: %d byte", [(NSData*)obj length]);
+                }
+                else {
+                    NSLog(@"obj: %@", obj);
+                }
             }
             
             idx++;


### PR DESCRIPTION
Hi. When large blob is inserted and `traceExecution` is set to `YES`, FMDB will ns-log every byte and causes debugging slow, so I suppressed it by logging data-bytes instead.

It'll be glad if you merge this to your master branch!
