### PR TITLE
Add methods to use NSData when setting database key

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -90,6 +90,8 @@
 // encryption methods.  You need to have purchased the sqlite encryption extensions for these to work.
 - (BOOL)setKey:(NSString*)key;
 - (BOOL)rekey:(NSString*)key;
+- (BOOL)setKeyWithData:(NSData *)keyData;
+- (BOOL)rekeyWithData:(NSData *)keyData;
 
 - (NSString *)databasePath;
 

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -210,12 +210,18 @@
 
 
 - (BOOL)rekey:(NSString*)key {
+    NSData *keyData = [NSData dataWithBytes:(void *)[key UTF8String] length:(int)strlen([key UTF8String])];
+    
+    return [self rekeyWithData:keyData];
+}
+
+- (BOOL)rekeyWithData:(NSData *)keyData {
 #ifdef SQLITE_HAS_CODEC
-    if (!key) {
+    if (!keyData) {
         return NO;
     }
     
-    int rc = sqlite3_rekey(_db, [key UTF8String], (int)strlen([key UTF8String]));
+    int rc = sqlite3_rekey(_db, [keyData bytes], [keyData length]);
     
     if (rc != SQLITE_OK) {
         NSLog(@"error on rekey: %d", rc);
@@ -229,12 +235,18 @@
 }
 
 - (BOOL)setKey:(NSString*)key {
+    NSData *keyData = [NSData dataWithBytes:[key UTF8String] length:(int)strlen([key UTF8String])];
+    
+    return [self setKeyWithData:keyData];
+}
+
+- (BOOL)setKeyWithData:(NSData *)keyData {
 #ifdef SQLITE_HAS_CODEC
-    if (!key) {
+    if (!keyData) {
         return NO;
     }
     
-    int rc = sqlite3_key(_db, [key UTF8String], (int)strlen([key UTF8String]));
+    int rc = sqlite3_key(_db, [keyData bytes], [keyData length]);
     
     return (rc == SQLITE_OK);
 #else


### PR DESCRIPTION
If you are using an encrypted SQLite and have a key passphrase that may contain
non-UTF8 friendly bytes (or NULLs), you should use these methods instead.

-setKey: and -rekey: work exactly as before. Note that this means if you pass
them an NSString into which you have stuffed NULLs, they will truncate to the
first null byte when sending to the underlying sqlite functions.
