### PR TITLE
Don't block the calling thread.

### DIFF
--- a/src/FMDatabaseQueue.m
+++ b/src/FMDatabaseQueue.m
@@ -47,7 +47,7 @@
         
         _path = FMDBReturnRetained(aPath);
         
-        _queue = dispatch_queue_create([[NSString stringWithFormat:@"fmdb.%@", self] UTF8String], NULL);
+        _queue = dispatch_queue_create([[NSString stringWithFormat:@"fmdb.%@", self] UTF8String], DISPATCH_QUEUE_SERIAL);
     }
     
     return self;
@@ -95,7 +95,7 @@
 - (void)inDatabase:(void (^)(FMDatabase *db))block {
     FMDBRetain(self);
     
-    dispatch_sync(_queue, ^() {
+    dispatch_async(_queue, ^() {
         
         FMDatabase *db = [self database];
         block(db);
@@ -111,7 +111,7 @@
 
 - (void)beginTransaction:(BOOL)useDeferred withBlock:(void (^)(FMDatabase *db, BOOL *rollback))block {
     FMDBRetain(self);
-    dispatch_sync(_queue, ^() { 
+    dispatch_async(_queue, ^() {
         
         BOOL shouldRollback = NO;
         
@@ -149,7 +149,7 @@
     static unsigned long savePointIdx = 0;
     __block NSError *err = 0x00;
     FMDBRetain(self);
-    dispatch_sync(_queue, ^() { 
+    dispatch_async(_queue, ^() {
         
         NSString *name = [NSString stringWithFormat:@"savePoint%ld", savePointIdx++];
         


### PR DESCRIPTION
The FMDatabaseQueue called dispatch_sync over a queue to ensure they won't be concurrent.

The problem is that dispatch_sync also blocks the calling thread...
Also, dispatch_sync doesn't stop other threads to run on the same queue, it was the queue that implicitly when created, was serial, therefore making sure FMDatabase wasn't used twice. 

My Changes:
- Explicitly create the _queue as DISPATCH_QUEUE_SERIAL.
- replace dispatch_sync by dispatch_async.
