### PR TITLE
Add -[FMResultSet typeInformation] to mitigate missing type information in FMResultSet.

### DIFF
--- a/src/FMResultSet.h
+++ b/src/FMResultSet.h
@@ -13,6 +13,13 @@
 #endif
 #endif
 
+typedef enum {
+    FMColumnTypeOther,
+    FMColumnTypeInteger,
+    FMColumnTypeFloat,
+    FMColumnTypeBlob
+} FMColumnType;
+
 @class FMDatabase;
 @class FMStatement;
 
@@ -41,6 +48,9 @@
 
 - (int)columnIndexForName:(NSString*)columnName;
 - (NSString*)columnNameForIndex:(int)columnIdx;
+
+- (FMColumnType)columnTypeForColumn:(NSString*)columnName;
+- (FMColumnType)columnTypeForColumnIndex:(int)columnIdx;
 
 - (int)intForColumn:(NSString*)columnName;
 - (int)intForColumnIndex:(int)columnIdx;

--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -219,6 +219,27 @@
     return -1;
 }
 
+- (FMColumnType)columnTypeForColumn:(NSString*)columnName {
+    return [self columnTypeForColumnIndex:[self columnIndexForName:columnName]];
+}
+
+- (FMColumnType)columnTypeForColumnIndex:(int)columnIdx {
+    int columnType = sqlite3_column_type([_statement statement], columnIdx);
+
+    switch (columnType) {
+    case SQLITE_INTEGER:
+        return FMColumnTypeInteger;
+
+    case SQLITE_FLOAT:
+        return FMColumnTypeFloat;
+
+    case SQLITE_BLOB:
+        return FMColumnTypeBlob;
+
+    default:
+        return FMColumnTypeOther;
+    }
+}
 
 
 - (int)intForColumn:(NSString*)columnName {


### PR DESCRIPTION
The FMResultSet API destroys column information in the database,
particularly in the float vs integer case. As a result, the
-[FMResultSet resultDictionary] API smashes both ints and floats
together as NSNumber*, making it difficult to introspect.

This API allows a minimal amount of introspection to work around
this problem.

In my case, I needed this API to deal with a fairly run-of-the-mill floating point formatting issue, since SQLite doesn't have actual decimal types.
