### PR TITLE
Fixes a variable argument crash if an incorrect number of arguments are passed in

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -630,12 +630,16 @@
             
         while (idx < queryCount) {
             
-            if (arrayArgs) {
+            if (arrayArgs && idx < [arrayArgs count]) {
                 obj = [arrayArgs objectAtIndex:(NSUInteger)idx];
             }
-            else {
+            else if (args) {
                 obj = va_arg(args, id);
             }
+			else {
+				//We ran out of arguments
+				break;
+			}
             
             if (_traceExecution) {
                 NSLog(@"obj: %@", obj);
@@ -815,12 +819,16 @@
         
         while (idx < queryCount) {
             
-            if (arrayArgs) {
+            if (arrayArgs && idx < [arrayArgs count]) {
                 obj = [arrayArgs objectAtIndex:(NSUInteger)idx];
             }
-            else {
+            else if (args) {
                 obj = va_arg(args, id);
             }
+			else {
+				//We ran out of arguments
+				break;
+			}
             
             if (_traceExecution) {
                 NSLog(@"obj: %@", obj);


### PR DESCRIPTION
Reproducible with the FMDBReportABugFunction function by changing the query to the following:

FMResultSet *rs = [db executeQuery:@"select \* from test where c=?" withArgumentsInArray:@[]];
