### PR TITLE
Add link to class reference to README

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -12,7 +12,7 @@ If you would like to contribute some code- awesome!  I just ask that you make it
 
         - If you want online help integrated right into Xcode, you can issue the command:
 
-            appledoc --project-name FMDB --project-company ccgus --explicit-crossref --merge-categories --install-docset --output ../Documentation .
+             appledoc --project-name FMDB --project-company ccgus --explicit-crossref --merge-categories --install-docset --output ../Documentation .
 
 2013.05.24
     Merged in Chris Wright's date format additions to FMDatabase.

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,8 @@
 # FMDB
 This is an Objective-C wrapper around SQLite: http://sqlite.org/
 
+Also please see the [FMDB Class Reference](http://ccgus.github.io/fmdb/html/index.html).
+
 ## The FMDB Mailing List:
 http://groups.google.com/group/fmdb
 


### PR DESCRIPTION
In pull request 154 (https://github.com/ccgus/fmdb/pull/154), I've added the class reference documentation to gh-pages.

In this pull request, I'm adding a link to that in the README. This pull request only makes sense if you accept 154 (and, in fact, the link won't even work until/if you merge 154).
