### PR TITLE
FMDatabase: fixes static analyzer warning, API Misuse (Apple)

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -704,7 +704,7 @@
         statement = [[FMStatement alloc] init];
         [statement setStatement:pStmt];
         
-        if (_shouldCacheStatements) {
+        if (_shouldCacheStatements && sql) {
             [self setCachedStatement:statement forQuery:sql];
         }
     }


### PR DESCRIPTION
FMDatabase.m:207:5: Key argument to 'setObject:forKey:' cannot be nil

trace:

FMDatabase.m:207:5: Key argument to 'setObject:forKey:' cannot be nil
FMDatabase.m:584:9: Assuming pointer value is null
FMDatabase.m:590:17: Assuming 'statement' is nil
FMDatabase.m:600:48: 'UTF8String' not called because the receiver is nil
FMDatabase.m:602:17: Assuming 'rc' is not equal to 5
FMDatabase.m:602:38: Assuming 'rc' is not equal to 6
FMDatabase.m:614:22: Assuming 'rc' is equal to 0
FMDatabase.m:641:9: Assuming 'dictionaryArgs' is nil
FMDatabase.m:666:16: Assuming 'idx' is >= 'queryCount'
FMDatabase.m:666:16: Loop body executed 0 times
FMDatabase.m:690:9: Assuming 'idx' is equal to 'queryCount'
FMDatabase.m:704:13: Calling 'setCachedStatement:forQuery:'
FMDatabase.m:201:1: Entered call from 'executeQuery:withArgumentsInArray:orDictionary:orVAList:'
FMDatabase.m:203:14: 'copy' not called because the receiver is nil
FMDatabase.m:203:5: nil object reference stored to 'query'
FMDatabase.m:207:5: Key argument to 'setObject:forKey:' cannot be nil
