### PR TITLE
Update header/documentation for hasAnotherRow

### DIFF
--- a/src/FMResultSet.h
+++ b/src/FMResultSet.h
@@ -77,13 +77,19 @@
  You must always invoke `next` before attempting to access the values returned in a query, even if you're only expecting one.
 
  @return `YES` if row successfully retrieved; `NO` if end of result set reached
+ 
+ @see hasAnotherRow
  */
 
 - (BOOL)next;
 
-/** Does the result set have another row?
+/** Did the last call to `<next>` succeed in retrieving another row?
 
- @return `YES` if there is another row; `NO` if not.
+ @return `YES` if the last call to `<next>` succeeded in retrieving another record; `NO` if not.
+ 
+ @see next
+ 
+ @warning The `hasAnotherRow` method must follow a call to `<next>`. If the previous database interaction was something other than a call to `next`, then this method may return `NO`, whether there is another row of data or not.
  */
 
 - (BOOL)hasAnotherRow;


### PR DESCRIPTION
I noticed that the `hasAnotherRow` documentation was unclear (I wrote it, so there's no one to blame but me). It could have led someone to believe that this would tell you whether there was another row and therefore whether the _next_ invocation of the `next` method would succeed. But this actually only tells you whether the _previous_ invocation succeeded or not.
