### PR TITLE
Data Sanitization of enumerable arguments in [FMDatabase executeQuery:withArgumentsInArray:]

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -13,6 +13,8 @@
 
     #define FMDBRelease(__v) ([__v release]);
 
+    #define FMDBAutoreleasing
+
 	#define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
 #else
     // -fobjc-arc
@@ -23,6 +25,8 @@
     #define FMDBReturnRetained(__v) (__v)
 
     #define FMDBRelease(__v)
+
+    #define FMDBAutoreleasing __autoreleasing
 
 	#if TARGET_OS_IPHONE
 		// Compiling for iOS

--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -13,8 +13,6 @@
 
     #define FMDBRelease(__v) ([__v release]);
 
-    #define FMDBAutoreleasing
-
 	#define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
 #else
     // -fobjc-arc
@@ -25,8 +23,6 @@
     #define FMDBReturnRetained(__v) (__v)
 
     #define FMDBRelease(__v)
-
-    #define FMDBAutoreleasing __autoreleasing
 
 	#if TARGET_OS_IPHONE
 		// Compiling for iOS

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -6,7 +6,7 @@
 
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;
 - (BOOL)executeUpdate:(NSString*)sql error:(NSError**)outErr withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;
-- (BOOL)expandCollectionArgumentsInSQL:(NSString *)sql withArgumentsInArray:(NSArray *)arguments intoSQL:(NSString * FMDBAutoreleasing *)outExpandedSQL arguments:(NSArray * FMDBAutoreleasing *)outExpandedArguments error:(NSError * FMDBAutoreleasing *)outError;
+- (BOOL)expandCollectionArgumentsInSQL:(NSString *)sql withArgumentsInArray:(NSArray *)arguments intoSQL:(NSString **)outExpandedSQL arguments:(NSArray **)outExpandedArguments error:(NSError **)outError;
 @end
 
 @implementation FMDatabase
@@ -1206,7 +1206,7 @@ void FMDBBlockSQLiteCallBackFunction(sqlite3_context *context, int argc, sqlite3
 #endif
 }
 
-- (BOOL)expandCollectionArgumentsInSQL:(NSString *)sql withArgumentsInArray:(NSArray *)arguments intoSQL:(NSString * FMDBAutoreleasing *)outExpandedSQL arguments:(NSArray * FMDBAutoreleasing *)outExpandedArguments error:(NSError * FMDBAutoreleasing *)outError
+- (BOOL)expandCollectionArgumentsInSQL:(NSString *)sql withArgumentsInArray:(NSArray *)arguments intoSQL:(NSString **)outExpandedSQL arguments:(NSArray **)outExpandedArguments error:(NSError **)outError
 {
     // Basic support for binding `?` to an NSArray, NSSet, NSOrderedSet arguments:
     //

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -745,117 +745,17 @@
 }
 
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray *)arguments {
-
-    // Basic support for binding `?` to an NSArray, NSSet, NSOrderedSet arguments:
-    //
-    // Replace the `?` characters bound to such arguments with a comma-separated
-    // list of question marks, `?,?,...`, with as many parameters as there are
-    // in the enumerable, and flatten the arguments array.
-    //
-    // Caveat 1: we do not process queries containing `?` characters that are not
-    // parameters (such as question marks embedded in literal strings). We only
-    // process queries if and only if there is the same number of question marks
-    // and arguments.
-    //
-    // Caveat 2: we do not process queries containing `?NNN` parameters.
-    
-    // enumerableIndexSet contain indexes of enumerable arguments
-    
-    Class NSOrderedSetClass = NSClassFromString(@"NSOrderedSet");   // NSOrderedSet class may not exist yet.
-    NSMutableIndexSet *enumerableIndexSet = [NSMutableIndexSet indexSet];
-    NSUInteger argumentsCount = arguments.count;
-    for (NSUInteger i = 0; i < argumentsCount; ++i) {
-        id argument = [arguments objectAtIndex:i];
-        if ([argument isKindOfClass:[NSArray class]]) {
-            [enumerableIndexSet addIndex:i];
-        }
-        else if ([argument isKindOfClass:[NSSet class]]) {
-            [enumerableIndexSet addIndex:i];
-        }
-        else if (NSOrderedSetClass && [argument isKindOfClass:NSOrderedSetClass]) {
-            [enumerableIndexSet addIndex:i];
-        }
+    NSString *expandedSQL = nil;
+    NSArray *expandedArguments = nil;
+    NSError *error;
+    if (![self expandSQL:sql argumentsInArray:arguments expandedSQL:&expandedSQL expandedArguments:&expandedArguments error:&error]) {
+        // Log expansion errors, and process raw input
+        NSLog(@"warning: %@", error.localizedDescription);
+        expandedSQL = sql;
+        expandedArguments = arguments;
     }
     
-    if (enumerableIndexSet.count > 0) {
-        
-        // We have enumerable argument(s).
-        // Now check that we have as many question marks as we have arguments.
-        
-        NSArray *SQLChunks = [sql componentsSeparatedByString:@"?"];
-        NSUInteger SQLChunkCount = SQLChunks.count;
-        
-        if (SQLChunkCount == argumentsCount + 1) {
-            
-            // We have as many `?` as we have arguments.
-            // Now check that none of them are `?NNN` positioned parameters:
-            
-            BOOL queryContainsPositionedParameters = NO;
-            for (NSUInteger i = 1; i < SQLChunkCount; ++i) {
-                NSString *SQLChunk = [SQLChunks objectAtIndex:i];
-                unichar characterFollowingQuestionMark = [SQLChunk characterAtIndex:0];
-                if (characterFollowingQuestionMark >= '0' && characterFollowingQuestionMark <= '9') {
-                    queryContainsPositionedParameters = YES;
-                    break;
-                }
-            }
-            
-            
-            if (!queryContainsPositionedParameters) {
-                
-                // OK, let's process the query
-                
-                NSMutableArray *rewrittenArguments = [NSMutableArray array];                // flat arguments
-                NSMutableString *rewrittenSQL = [[SQLChunks objectAtIndex:0] mutableCopy];  // query with expanded `?,?,...`
-                NSEnumerator *SQLChunkEnumerator = [SQLChunks objectEnumerator];
-                [SQLChunkEnumerator nextObject];
-                
-                for (NSUInteger i = 0; i < argumentsCount; ++i) {
-                    id argument = [arguments objectAtIndex:i];
-                    
-                    if ([enumerableIndexSet containsIndex:i]) {
-                        
-                        // enumerable argument
-                        
-                        BOOL initial = YES;
-                        for (id object in argument) {
-                            if (initial) {
-                                [rewrittenSQL appendString:@"?"];
-                            } else {
-                                [rewrittenSQL appendString:@",?"];
-                            }
-                            [rewrittenArguments addObject:object];
-                            initial = NO;
-                        }
-                    }
-                    else {
-                        
-                        // non-enumerable argument
-                        
-                        [rewrittenSQL appendString:@"?"];
-                        [rewrittenArguments addObject:argument];
-                    }
-                    
-                    [rewrittenSQL appendString:[SQLChunkEnumerator nextObject]];
-                }
-                
-                sql = rewrittenSQL;
-                arguments = rewrittenArguments;
-            }
-            else {
-                // We do not support `?NNN` positioned parameters.
-                // Leave SQL and arguments untouched, but emit a warning, because the user will be bitten.
-                NSLog(@"%@ warning: NSArray arguments could not be bound, because the query contains a `?NNN` parameter.", self);
-            }
-        }
-        else {
-            // We do not have as many `?` as we have arguments: we don't know which ones are bound to arrays :-(
-            // Leave SQL and arguments untouched, but emit a warning, because the user will be bitten.
-            NSLog(@"%@ warning: NSArray arguments could not be bound. You may flatten arguments, and provide as many matching `?` in the query.", self);
-        }
-    }
-    
-    return [self executeQuery:sql withArgumentsInArray:arguments orDictionary:nil orVAList:nil];
+    return [self executeQuery:expandedSQL withArgumentsInArray:expandedArguments orDictionary:nil orVAList:nil];
 }
 
 - (BOOL)executeUpdate:(NSString*)sql error:(NSError**)outErr withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args {
@@ -1090,7 +990,17 @@
 }
 
 - (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray *)arguments {
-    return [self executeUpdate:sql error:nil withArgumentsInArray:arguments orDictionary:nil orVAList:nil];
+    NSString *expandedSQL = nil;
+    NSArray *expandedArguments = nil;
+    NSError *error;
+    if (![self expandSQL:sql argumentsInArray:arguments expandedSQL:&expandedSQL expandedArguments:&expandedArguments error:&error]) {
+        // Log expansion errors, and process raw input
+        NSLog(@"warning: %@", error.localizedDescription);
+        expandedSQL = sql;
+        expandedArguments = arguments;
+    }
+    
+    return [self executeUpdate:expandedSQL error:nil withArgumentsInArray:expandedArguments orDictionary:nil orVAList:nil];
 }
 
 - (BOOL)executeUpdate:(NSString*)sql withParameterDictionary:(NSDictionary *)arguments {
@@ -1283,6 +1193,113 @@ void FMDBBlockSQLiteCallBackFunction(sqlite3_context *context, int argc, sqlite3
 #else
     sqlite3_create_function([self sqliteHandle], [name UTF8String], count, SQLITE_UTF8, (__bridge void*)b, &FMDBBlockSQLiteCallBackFunction, 0x00, 0x00);
 #endif
+}
+
+- (BOOL)expandSQL:(NSString *)sql argumentsInArray:(NSArray *)arguments expandedSQL:(NSString * FMDBAutoreleasing *)outExpandedSQL expandedArguments:(NSArray * FMDBAutoreleasing *)outExpandedArguments error:(NSError * FMDBAutoreleasing *)outError;
+{
+    // Basic support for binding `?` to an NSArray, NSSet, NSOrderedSet arguments:
+    //
+    // Replace the `?` characters bound to such arguments with a comma-separated
+    // list of question marks, `?,?,...`, with as many parameters as there are
+    // in the enumerable, and flatten the arguments array.
+    //
+    // Caveat 1: we do not process queries containing `?` characters that are not
+    // parameters (such as question marks embedded in literal strings). We only
+    // process queries if and only if there is the same number of question marks
+    // and arguments.
+    //
+    // Caveat 2: we do not process queries containing `?NNN` parameters.
+    
+    
+    // Look for enumerable arguments:
+    // enumerableIndexSet contain indexes of enumerable arguments
+    
+    Class NSOrderedSetClass = NSClassFromString(@"NSOrderedSet");   // NSOrderedSet class may not exist yet.
+    NSMutableIndexSet *enumerableIndexSet = [NSMutableIndexSet indexSet];
+    NSUInteger argumentsCount = arguments.count;
+    for (NSUInteger i = 0; i < argumentsCount; ++i) {
+        id argument = [arguments objectAtIndex:i];
+        if ([argument isKindOfClass:[NSArray class]] || [argument isKindOfClass:[NSSet class]] || (NSOrderedSetClass && [argument isKindOfClass:NSOrderedSetClass])) {
+            [enumerableIndexSet addIndex:i];
+        }
+    }
+    
+    
+    // Check that we have any enumerable arguments
+    
+    if (enumerableIndexSet.count == 0) {
+        if (outExpandedSQL) *outExpandedSQL = sql;
+        if (outExpandedArguments) *outExpandedArguments = arguments;
+        return YES;
+    }
+    
+    
+    // We have enumerable argument(s).
+    // Now check that we have as many question marks as we have arguments.
+    
+    NSArray *SQLChunks = [sql componentsSeparatedByString:@"?"];
+    NSUInteger SQLChunkCount = SQLChunks.count;
+    
+    if (SQLChunkCount != argumentsCount + 1) {
+        // We do not have as many `?` as we have arguments: we don't know which ones are bound to arrays :-(
+        if (outError) *outError = [self errorWithMessage:@"NSArray arguments could not be bound. You may flatten arguments, and provide as many matching `?` in the query."];
+        return NO;
+    }
+    
+    
+    // We have as many `?` as we have arguments.
+    // Now check that none of them are `?NNN` positioned parameters:
+    
+    for (NSUInteger i = 1; i < SQLChunkCount; ++i) {
+        NSString *SQLChunk = [SQLChunks objectAtIndex:i];
+        unichar characterFollowingQuestionMark = [SQLChunk characterAtIndex:0];
+        if (characterFollowingQuestionMark >= '0' && characterFollowingQuestionMark <= '9') {
+            // We do not support `?NNN` positioned parameters.
+            if (outError) *outError = [self errorWithMessage:@"NSArray arguments could not be bound, because the query contains a `?NNN` parameter."];
+            return NO;
+        }
+    }
+    
+    
+    // OK, let's expand SQL and arguments
+    
+    NSMutableArray *expandedArguments = [NSMutableArray array];                // expanded arguments
+    NSMutableString *expandedSQL = [[SQLChunks objectAtIndex:0] mutableCopy];  // query with expanded `?,?,...`
+    NSEnumerator *SQLChunkEnumerator = [SQLChunks objectEnumerator];
+    [SQLChunkEnumerator nextObject];
+    
+    for (NSUInteger i = 0; i < argumentsCount; ++i) {
+        id argument = [arguments objectAtIndex:i];
+        
+        if ([enumerableIndexSet containsIndex:i]) {
+            
+            // enumerable argument
+            
+            BOOL initial = YES;
+            for (id object in argument) {
+                if (initial) {
+                    [expandedSQL appendString:@"?"];
+                } else {
+                    [expandedSQL appendString:@",?"];
+                }
+                [expandedArguments addObject:object];
+                initial = NO;
+            }
+        }
+        else {
+            
+            // non-enumerable argument
+            
+            [expandedSQL appendString:@"?"];
+            [expandedArguments addObject:argument];
+        }
+        
+        [expandedSQL appendString:[SQLChunkEnumerator nextObject]];
+    }
+    
+    if (outExpandedSQL) *outExpandedSQL = expandedSQL;
+    if (outExpandedArguments) *outExpandedArguments = expandedArguments;
+    return YES;
 }
 
 @end


### PR DESCRIPTION
Hi,

This commit provides data sanitization of NSArray, NSSet and NSOrderedSet arguments in [FMDatabase executeQuery:withArgumentsInArray:], and solves two problems:
1. FMDB 2.1 requires users to provide as many question marks in the query as there are elements, and this is tedious when the enumerable object has a variable length.
2. FMDB 2.1 surprises users who do not know well the internals of sqlite, and expect enumerables to be transparently expanded, as in famous ORMs such as ActiveRecord.

For example:

``` objc
// Note the single question mark bound to an NSArray object.
ids = @[@1, @2, @3];
[db executeQuery:@"SELECT * FROM table WHERE id IN (?)" withArgumentsInArray:@[ids]]
```

There are a few caveats, though. They are documented in the method implementation (see attached code).

I hope you'll find this patch useful, and that we'll improve it together.
