### PR TITLE
Some fixes

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -1067,11 +1067,9 @@
 
 - (BOOL)startSavePointWithName:(NSString*)name error:(NSError**)outErr {
     
-    // FIXME: make sure the savepoint name doesn't have a ' in it.
-    
     NSParameterAssert(name);
     
-    if (![self executeUpdate:[NSString stringWithFormat:@"savepoint '%@';", name]]) {
+    if (![self executeUpdate:@"savepoint '?';", name]) {
 
         if (outErr) {
             *outErr = [self lastError];
@@ -1087,7 +1085,7 @@
     
     NSParameterAssert(name);
     
-    BOOL worked = [self executeUpdate:[NSString stringWithFormat:@"release savepoint '%@';", name]];
+    BOOL worked = [self executeUpdate:@"release savepoint '?';", name];
     
     if (!worked && outErr) {
         *outErr = [self lastError];
@@ -1100,7 +1098,7 @@
     
     NSParameterAssert(name);
     
-    BOOL worked = [self executeUpdate:[NSString stringWithFormat:@"rollback transaction to savepoint '%@';", name]];
+    BOOL worked = [self executeUpdate:@"rollback transaction to savepoint '?';", name];
     
     if (!worked && outErr) {
         *outErr = [self lastError];


### PR DESCRIPTION
This removes one crasher (if you didn't pass an error to `-rollbackToSavePointWithName:`) and a FIXME (how save point names are generated and passed to SQLite).

To be frank, I actually :

1) wrote my own wrapper around `-beginTransaction`/`-commit`/`-rollback`,
2) noticed that SQLite doesn't nest transactions,
3) learned of save points,
4) wrote another wrapper,
5) discovered `-inSavePoint:` existed.

My own save point version used a `CFUUIDRef`, and I can switch it here if you're interested.
