### PR TITLE
Change the block's signature of `inSavePoint:`.

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -942,7 +942,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  
  */
 
-- (NSError*)inSavePoint:(void (^)(BOOL *rollback))block;
+- (NSError*)inSavePoint:(BOOL (^)(void))block;
 
 ///----------------------------
 /// @name SQLite library status

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1362,26 +1362,21 @@ static NSString *FMDBEscapeSavePointName(NSString *savepointName) {
 #endif
 }
 
-- (NSError*)inSavePoint:(void (^)(BOOL *rollback))block {
+- (NSError*)inSavePoint:(BOOL (^)(void))block {
 #if SQLITE_VERSION_NUMBER >= 3007000
     static unsigned long savePointIdx = 0;
     
     NSString *name = [NSString stringWithFormat:@"dbSavePoint%ld", savePointIdx++];
-    
-    BOOL shouldRollback = NO;
-    
+
     NSError *err = 0x00;
     
     if (![self startSavePointWithName:name error:&err]) {
         return err;
     }
     
-    if (block) {
-        block(&shouldRollback);
-    }
+    BOOL success = block();
     
-    if (shouldRollback) {
-        // We need to rollback and release this savepoint to remove it
+    if (!success) {
         [self rollbackToSavePointWithName:name error:&err];
     }
     [self releaseSavePointWithName:name error:&err];


### PR DESCRIPTION
This is open to discussion, but

```
[db inSavePoint:^BOOL{
    return [self performSomethingThatFailsWithNO];
}];
```

looks tastier than

```
[db inSavePoint:^(BOOL *rollback){
    BOOL result = [self performSomethingThatFailsWithNO];
    if (!result) {
        *rollback = YES;
        return;
    }
}];
```
