### PR TITLE
Changed `isEqualTo:` (AppleScript support) to `isEqual:` (NSObject)

### DIFF
--- a/src/fmdb.m
+++ b/src/fmdb.m
@@ -155,10 +155,10 @@ int main (int argc, const char * argv[]) {
     rs = [db executeQuery:@"select rowid, a, b, c from test"];
     while ([rs next]) {
         
-        FMDBQuickCheck([rs[0] isEqualTo:rs[@"rowid"]]);
-        FMDBQuickCheck([rs[1] isEqualTo:rs[@"a"]]);
-        FMDBQuickCheck([rs[2] isEqualTo:rs[@"b"]]);
-        FMDBQuickCheck([rs[3] isEqualTo:rs[@"c"]]);
+        FMDBQuickCheck([rs[0] isEqual:rs[@"rowid"]]);
+        FMDBQuickCheck([rs[1] isEqual:rs[@"a"]]);
+        FMDBQuickCheck([rs[2] isEqual:rs[@"b"]]);
+        FMDBQuickCheck([rs[3] isEqual:rs[@"c"]]);
     }
     [rs close];
     


### PR DESCRIPTION
The method `isEqualTo:` is part of the scripting support API (for computing `NSWhoseSpecifier`s specifically), the proper selector would thus be `isEqual:`.

Reference: https://developer.apple.com/library/mac/documentation/cocoa/reference/foundation/Protocols/NSComparisonMethods_Protocol/Reference/Reference.html#//apple_ref/occ/instm/NSObject/isEqualTo:
