### PR TITLE
Faster columnAtIndex:

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -3,6 +3,11 @@ Zip, nada, zilch.  Got any ideas?
 
 If you would like to contribute some code- awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add a couple of tests for your new code to fmdb.m.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
 
+2013.10.7
+    The date on the previous log is almost certainly wrong...
+
+    Improved columnIndexForName: performance by caching previous names.  Speeds up large fetch by 100% for me.
+
 2013.10.26
     Logs errors is now turned on by default.  It's easy to turn off, and if you're seeing errors then you should probably fix those.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,11 @@
 # FMDB
 This is an Objective-C wrapper around SQLite: http://sqlite.org/
 
+## Why this fork?
+
+I made a performance improvemnt, columnIndexForName: is significantly faster for common usage.
+(One of my very large fetches got 100% faster, 50% less time).
+
 ## The FMDB Mailing List:
 http://groups.google.com/group/fmdb
 

--- a/src/FMResultSet.h
+++ b/src/FMResultSet.h
@@ -29,6 +29,8 @@
     
     NSString            *_query;
     NSMutableDictionary *_columnNameToIndexMap;
+    id                  *_columnnames;
+    int                 columnCount;
 }
 
 ///-----------------


### PR DESCRIPTION
I noticed columnAtIndex: taking around 50% of the time for a large fetch.

This is a little patch that makes that time effectively just go away.  It remembers the pointers to the keys that were used and does a pointer comparison first, falling back to the full computation if no pointer matches (and updating the pointer table in that case).

Would break if the client (a) used mutable strings to access the columns and (b) changed the content of those mutable strings during the course of evaluating the result set.
