### PR TITLE
fix for statement caching issue

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -931,6 +931,12 @@
     sqlite3_stmt *_statement;
     NSString *_query;
     long _useCount;
+    
+#if __has_feature(objc_arc_weak)
+    __weak FMResultSet* _ownerResultSet;
+#else
+    FMResultSet* _ownerResultSet;
+#endif
 }
 
 ///-----------------
@@ -952,6 +958,14 @@
 
 @property (atomic, assign) sqlite3_stmt *statement;
 
+
+//** back reference to owning result-set  */
+
+#if __has_feature(objc_arc_weak)
+@property (atomic, weak) FMResultSet* ownerResultSet;
+#else
+@property (atomic, assign) FMResultSet* ownerResultSet;
+#endif
 
 ///----------------------------
 /// @name Closing and Resetting

--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -18,6 +18,9 @@
     [rs setStatement:statement];
     [rs setParentDB:aDB];
     
+    NSParameterAssert( statement.ownerResultSet == nil );
+    [statement setOwnerResultSet: rs]; // weak reference
+    
     return FMDBReturnAutoreleased(rs);
 }
 


### PR DESCRIPTION
This is a proposed fix for the statement caching issue described in https://github.com/ccgus/fmdb/issues/6

My approach is basically what @mattstevens proposes in the issue thread:  Cached statements are now only dolled out when they aren't currently associated with an open FMResultSet.  Once an associated result set is closed the cached statement becomes available for reuse.

I added a simple test case to fmdb.m to validate the fix and confirm that it doesn't break statement caching altogether.  All tests in fmdb.m apparently continue to pass.  I ran no other regression tests to see if I somehow broke something else.

My fix uses __weak, but I provided a non-arc/non-weak compilation path.  But this is untested.

I believe this fix negates the need for the fix applied for similar issue https://github.com/ccgus/fmdb/issues/106.  But that fix doesn't conflict with mine.
