### PR TITLE
Overriding the parent class designated initializer

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -29,6 +29,10 @@
     return sqlite3_threadsafe() != 0;
 }
 
+- (instancetype)init {
+    return [self initWithPath:nil];
+}
+
 - (instancetype)initWithPath:(NSString*)aPath {
     
     assert(sqlite3_threadsafe()); // whoa there big boy- gotta make sure sqlite it happy with what we're going to do.

--- a/src/FMDatabasePool.m
+++ b/src/FMDatabasePool.m
@@ -27,6 +27,10 @@
     return FMDBReturnAutoreleased([[self alloc] initWithPath:aPath]);
 }
 
+- (instancetype)init {
+    return [self initWithPath:nil];
+}
+
 - (instancetype)initWithPath:(NSString*)aPath {
     
     self = [super init];

--- a/src/FMDatabaseQueue.m
+++ b/src/FMDatabaseQueue.m
@@ -40,6 +40,7 @@
     return q;
 }
 
+
 - (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags {
     
     self = [super init];
@@ -74,6 +75,11 @@
     return [self initWithPath:aPath flags:SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE];
 }
 
+- (instancetype)init {
+    return [self initWithPath:nil];
+}
+
+    
 - (void)dealloc {
     
     FMDBRelease(_db);


### PR DESCRIPTION
Changed: `FMDatabase`, `FMDatabasePool` and `FMDatabaseQueue`.

This ensures that the class will be fully initialized even if using the designated initializer of NSObject.
Also, provides a nice default for the `path`: in memory database.

This change also makes it a little bit easier to integrate `FMDB` with https://github.com/atomicobject/objection.

Documentation: https://developer.apple.com/library/ios/documentation/general/conceptual/devpedia-cocoacore/MultipleInitializers.html
