### PR TITLE
Add checks for query passed to setCachedStatement

### DIFF
--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -213,19 +213,23 @@
 
 - (void)setCachedStatement:(FMStatement*)statement forQuery:(NSString*)query {
     
-    query = [query copy]; // in case we got handed in a mutable string...
-    [statement setQuery:query];
-    
-    NSMutableSet* statements = [_cachedStatements objectForKey:query];
-    if (!statements) {
-        statements = [NSMutableSet set];
+    if (query != nil) {
+        
+        query = [query copy]; // in case we got handed in a mutable string...
+        [statement setQuery:query];
+        
+        NSMutableSet* statements = [_cachedStatements objectForKey:query];
+        if (!statements) {
+            statements = [NSMutableSet set];
+        }
+        
+        [statements addObject:statement];
+        
+        [_cachedStatements setObject:statements forKey:query];
+        
+        FMDBRelease(query);
+        
     }
-    
-    [statements addObject:statement];
-    
-    [_cachedStatements setObject:statements forKey:query];
-    
-    FMDBRelease(query);
 }
 
 - (BOOL)rekey:(NSString*)key {


### PR DESCRIPTION
There is a chance to crash if pass query is nil, which might be a case having complex sql builder.
