### PR TITLE
Add support for openFlags to FMDatabasePool.

### DIFF
--- a/src/FMDatabasePool.h
+++ b/src/FMDatabasePool.h
@@ -40,11 +40,13 @@
     __unsafe_unretained id _delegate;
     
     NSUInteger          _maximumNumberOfDatabasesToCreate;
+    int                 _openFlags;
 }
 
 @property (atomic, retain) NSString *path;
 @property (atomic, assign) id delegate;
 @property (atomic, assign) NSUInteger maximumNumberOfDatabasesToCreate;
+@property (atomic, readonly) int openFlags;
 
 ///---------------------
 /// @name Initialization
@@ -59,6 +61,16 @@
 
 + (instancetype)databasePoolWithPath:(NSString*)aPath;
 
+/** Create pool using path and specified flags
+
+  @param aPath The file path of the database.
+  @param openFlags Flags passed to the openWithFlags method of the database
+
+ @return The `FMDatabasePool` object. `nil` on error.
+ */
+
++ (instancetype)databasePoolWithPath:(NSString*)aPath flags:(int)openFlags;
+
 /** Create pool using path.
 
  @param aPath The file path of the database.
@@ -67,6 +79,16 @@
  */
 
 - (instancetype)initWithPath:(NSString*)aPath;
+
+/** Create pool using path and specified flags.
+
+ @param aPath The file path of the database.
+ @param openFlags Flags passed to the openWithFlags method of the database
+
+ @return The `FMDatabasePool` object. `nil` on error.
+ */
+
+- (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags;
 
 ///------------------------------------------------
 /// @name Keeping track of checked in/out databases

--- a/src/FMDatabaseQueue.h
+++ b/src/FMDatabaseQueue.h
@@ -69,7 +69,7 @@
 }
 
 @property (atomic, retain) NSString *path;
-@property (atomic) int openFlags;
+@property (atomic, readonly) int openFlags;
 
 ///----------------------------------------------------
 /// @name Initialization, opening, and closing of queue

--- a/src/FMDatabaseQueue.m
+++ b/src/FMDatabaseQueue.m
@@ -111,7 +111,7 @@
 #if SQLITE_VERSION_NUMBER >= 3005000
         if (![_db openWithFlags:_openFlags]) {
 #else
-			if (![db open])
+        if (![db open]) {
 #endif
             NSLog(@"FMDatabaseQueue could not reopen database for path %@", _path);
             FMDBRelease(_db);

--- a/src/fmdb.m
+++ b/src/fmdb.m
@@ -1377,6 +1377,20 @@ void testPool(NSString *dbPath) {
         NSLog(@"Number of open databases after crazy gcd stuff: %ld", [dbPool countOfOpenDatabases]);
     }
     
+	FMDatabasePool *dbPool2 = [FMDatabasePool databasePoolWithPath:dbPath flags:SQLITE_OPEN_READONLY];
+    
+    FMDBQuickCheck(dbPool2);
+    {
+        [dbPool2 inDatabase:^(FMDatabase *db2) {
+            FMResultSet *rs1 = [db2 executeQuery:@"SELECT * FROM test"];
+            FMDBQuickCheck(rs1 != nil);
+            [rs1 close];
+            
+            BOOL ok = [db2 executeUpdate:@"insert into easy values (?)", [NSNumber numberWithInt:3]];
+            FMDBQuickCheck(!ok);
+        }];
+    }
+    
     
     // if you want to see a deadlock, just uncomment this line and run:
     //#define ONLY_USE_THE_POOL_IF_YOU_ARE_DOING_READS_OTHERWISE_YOULL_DEADLOCK_USE_FMDATABASEQUEUE_INSTEAD 1


### PR DESCRIPTION
Also specify that openFlags is read-only on FMDatabaseQueue.

This pull request adds support for openFlags to FMDatabasePool along similar lines to the support that was recently added to FMDatabaseQueue.
