### PR TITLE
Simplify conditionals used to determine whether dispatch objects need explicit releasing.

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -24,11 +24,14 @@
 
     #define FMDBRelease(__v)
 
-	#if OS_OBJECT_USE_OBJC
-		#define FMDBDispatchQueueRelease(__v)
-	#else
-		#define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
-	#endif
+// If OS_OBJECT_USE_OBJC=1, then the dispatch objects will be treated like ObjC objects
+// and will participate in ARC.
+// See the section on "Dispatch Queues and Automatic Reference Counting" in "Grand Central Dispatch (GCD) Reference" for details. 
+    #if OS_OBJECT_USE_OBJC
+        #define FMDBDispatchQueueRelease(__v)
+    #else
+        #define FMDBDispatchQueueRelease(__v) (dispatch_release(__v));
+    #endif
 #endif
 
 #if !__has_feature(objc_instancetype)


### PR DESCRIPTION
The /usr/include/os/object.h header states that dispatch queues need manual retain/release if OS_OBJECT_USE_OBJC=1.  Individual code-bases can opt out of this behaviour by defining OS_OBJECT_USE_OBJC=0.  This change simplifies checking whether dispatch queues participate in ARC or not.
