### PR TITLE
Fixing the result dictionary of an FMResultSet to use the first value of a column if a column name conflict occurs.

### DIFF
--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -131,7 +131,10 @@
             
             NSString *columnName = [NSString stringWithUTF8String:sqlite3_column_name([_statement statement], columnIdx)];
             id objectValue = [self objectForColumnIndex:columnIdx];
-            [dict setObject:objectValue forKey:columnName];
+            if (dict[columnName] != nil)
+                NSLog(@"Warning: Result set has multiple columns named %@. Using the value of the first column.", columnName);
+            else
+                [dict setObject:objectValue forKey:columnName];
         }
         
         return dict;


### PR DESCRIPTION
I ran into an issue when querying data using "SELECT \* FROM TABLE JOIN OTHER TABLE ...". Both tables had a couple conflicting column names, and thus the result dictionary was giving me the values from the joined table, and not the table. I believe that a warning should be thrown at a minimum, as well as default to the first value, rather than the second.

Please let me know if you have any questions. Thanks!
