### PR TITLE
Fix for issue #203: Add 'databaseClass' class method for FMDatabaseQueue.

### DIFF
--- a/src/FMDatabaseQueue.h
+++ b/src/FMDatabaseQueue.h
@@ -112,6 +112,15 @@
 
 - (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags;
 
+/** Returns the Class of 'FMDatabase' subclass, that will be used to instantiate database object.
+ 
+ Subclasses can override this method to return specified Class of 'FMDatabase' subclass.
+ 
+ @return The Class of 'FMDatabase' subclass, that will be used to instantiate database object.
+ */
+
++ (Class)databaseClass;
+
 /** Close database used by queue. */
 
 - (void)close;

--- a/src/FMDatabaseQueue.m
+++ b/src/FMDatabaseQueue.m
@@ -40,6 +40,10 @@
     return q;
 }
 
++ (Class)databaseClass
+{
+    return [FMDatabase class];
+}
 
 - (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags {
     
@@ -47,7 +51,7 @@
     
     if (self != nil) {
         
-        _db = [FMDatabase databaseWithPath:aPath];
+        _db = [[[self class] databaseClass] databaseWithPath:aPath];
         FMDBRetain(_db);
         
 #if SQLITE_VERSION_NUMBER >= 3005000


### PR DESCRIPTION
Subclasses can override this method to return specified Class of 'FMDatabase' subclass. 
