### PR TITLE
Change the use of #if / #endif

### DIFF
--- a/src/FMDatabasePool.m
+++ b/src/FMDatabasePool.m
@@ -128,10 +128,11 @@
         
         //This ensures that the db is opened before returning
 #if SQLITE_VERSION_NUMBER >= 3005000
-        if ([db openWithFlags:_openFlags]) {
+        BOOL success = [db openWithFlags:_openFlags];
 #else
-        if ([db open]) {
+        BOOL success = [db open];
 #endif
+        if (success) {
             if ([_delegate respondsToSelector:@selector(databasePool:shouldAddDatabaseToPool:)] && ![_delegate databasePool:self shouldAddDatabaseToPool:db]) {
                 [db close];
                 db = 0x00;

--- a/src/FMDatabaseQueue.m
+++ b/src/FMDatabaseQueue.m
@@ -54,10 +54,11 @@
         FMDBRetain(_db);
         
 #if SQLITE_VERSION_NUMBER >= 3005000
-        if (![_db openWithFlags:openFlags]) {
+        BOOL success = [_db openWithFlags:openFlags];
 #else
-        if (![_db open]) {
+        BOOL success = [_db open];
 #endif
+        if (!success) {
             NSLog(@"Could not create database queue for path %@", aPath);
             FMDBRelease(self);
             return 0x00;
@@ -112,10 +113,11 @@
         _db = FMDBReturnRetained([FMDatabase databaseWithPath:_path]);
         
 #if SQLITE_VERSION_NUMBER >= 3005000
-        if (![_db openWithFlags:_openFlags]) {
+        BOOL success = [_db openWithFlags:_openFlags];
 #else
-        if (![db open]) {
+        BOOL success = [db open];
 #endif
+        if (!success) {
             NSLog(@"FMDatabaseQueue could not reopen database for path %@", _path);
             FMDBRelease(_db);
             _db  = 0x00;


### PR DESCRIPTION
Previously, the documents item jump bar could get confused by the use of `#if` / `#endif` directives in the middle of an `if` statement. Thus, if you pulled down the document items jump bar (either by clicking on it or pressing <kbd>control</kbd>-<kbd>6</kbd>), you'd see an incomplete list of the methods (highlight added):

![before1](https://f.cloud.github.com/assets/1530768/1896695/f5ae5360-7bb0-11e3-8d32-862383664f2e.png)

With this commit, `FMDatabaseQueue` and `FMDatabasePool` will show a complete list of method names:

![after1](https://f.cloud.github.com/assets/1530768/1896697/08fbd442-7bb1-11e3-8149-fc9631912456.png)

It makes it a little easier to navigate the FMDB code.
