### PR TITLE
Add batch update method

### DIFF
--- a/src/FMDatabase.h
+++ b/src/FMDatabase.h
@@ -341,6 +341,9 @@
 // Documentation forthcoming.
 - (BOOL)executeUpdate:(NSString*)sql withVAList: (va_list)args;
 
+// Documentation forthcoming.
+- (BOOL)executeBatchUpdate:(NSString*)sql error:(NSError**)error;
+
 
 /** Last insert rowid
  

--- a/src/FMDatabase.m
+++ b/src/FMDatabase.m
@@ -1030,6 +1030,30 @@
     return [self executeUpdate:sql withArgumentsInArray:arguments];
 }
 
+
+
+- (BOOL)executeBatchUpdate:(NSString*)sql error:(NSError**)error
+{
+    char* errorOutput;
+    
+    sqlite3_exec(_db, "BEGIN;", NULL, NULL, &errorOutput);
+    int responseCode = sqlite3_exec(_db, [sql UTF8String], NULL, NULL, &errorOutput);
+    sqlite3_exec(_db, "COMMIT;", NULL, NULL, &errorOutput);
+    
+    if (errorOutput != nil)
+    {
+        *error = [NSError errorWithDomain:[NSString stringWithUTF8String:errorOutput]
+                                     code:responseCode
+                                 userInfo:nil];
+        
+        sqlite3_free(errorOutput);
+        return false;
+    }
+    
+    return true;
+}
+
+
 - (BOOL)update:(NSString*)sql withErrorAndBindings:(NSError**)outErr, ... {
     va_list args;
     va_start(args, outErr);


### PR DESCRIPTION
In some scenarios, we need to insert or update thousands items in the database. If we call excuteUpdate function for thousands times, it will take a lot of time and the performance is really low.  So I wrote a excuteBatchUpdate method by which we could batch insert or update the database with only one time. It saves the time and performance.
