### PR TITLE
Rollback transactions when handling exceptions.

### DIFF
--- a/Tests/FMDatabaseQueueTests.m
+++ b/Tests/FMDatabaseQueueTests.m
@@ -173,4 +173,62 @@
 
 }
 
+-(void) testRollbackTransaction
+{
+
+    @try {
+
+        [self.queue inTransaction:^(FMDatabase *adb, BOOL* rollback) {
+            [adb executeUpdate:@"INSERT INTO easy VALUES (?)", [NSNumber numberWithInt:42]];
+            @throw [[NSException alloc] initWithName:@"Test" reason:@"TestException" userInfo:@{}];
+        }];
+
+        XCTFail(@"Didn't throw exception");
+
+    } @catch (NSException *exception) {
+    
+        __block BOOL hasResults = 0;
+    
+        [self.queue inDatabase:^(FMDatabase *adb) {
+            FMResultSet *results = [adb executeQuery:@"SELECT * FROM easy"];
+            hasResults = [results hasAnotherRow];
+            [results close];
+        }];
+
+        XCTAssertFalse(hasResults, @"Commit should not have succeeded.");
+
+    }
+
+
+}
+
+-(void) testRollbackSavePoint
+{
+    
+    @try {
+        
+        [self.queue inSavePoint:^(FMDatabase *adb, BOOL* rollback) {
+            [adb executeUpdate:@"INSERT INTO easy VALUES (?)", [NSNumber numberWithInt:42]];
+            @throw [[NSException alloc] initWithName:@"Test" reason:@"TestException" userInfo:@{}];
+        }];
+
+        XCTFail(@"Didn't throw exception");
+        
+    } @catch (NSException *exception) {
+        
+        __block BOOL hasResults = 0;
+
+        [self.queue inDatabase:^(FMDatabase *adb) {
+            FMResultSet *results = [adb executeQuery:@"SELECT * FROM easy"];
+            hasResults = [results hasAnotherRow];
+            [results close];
+        }];
+
+        XCTAssertFalse(hasResults, @"Commit should not have succeeded.");
+        
+    }
+    
+    
+}
+
 @end


### PR DESCRIPTION
So, I was looking over the source code and noticed that transactions don't seem to get rolled back if an exception is thrown.  

The way it's written it's not clear if an exception will result in a commit or rollback.  Though it is generally discouraged in Objective C, some people do rely on exceptions.  This pull request forces a roll back in the event of an exception.
