### PR TITLE
Change header export settings in FMDB and FMDB-IOS targets

### DIFF
--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -652,7 +652,9 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
@@ -678,7 +680,9 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				VALIDATE_PRODUCT = YES;
@@ -769,7 +773,9 @@
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				PRODUCT_NAME = FMDB;
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 			};
 			name = Debug;
 		};
@@ -780,7 +786,9 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				PRODUCT_NAME = FMDB;
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/FMDB;
 				ZERO_LINK = NO;
 			};
 			name = Release;


### PR DESCRIPTION
These changes cause the FMDB-IOS library target to export headers so projects that depend on FMDB-IOS can find those headers in a natural place under $(BUILT_PRODUCTS_DIR)/usr/local/include.

The second commit updates the header export paths of both FMDB and FMDB-IOS so that headers can be imported like:

```
#import <FMDB/FMDatabase.h>
```

instead of

```
#import <FMDatabase.h>
```
