### PR TITLE
Require ARC when using via CocoaPods.

### DIFF
--- a/fmdb.podspec
+++ b/fmdb.podspec
@@ -33,4 +33,6 @@ Pod::Spec.new do |s|
     ss.dependency 'FMDB/common'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC' }
   end
+  
+  s.requires_arc = true
 end


### PR DESCRIPTION
CocoaPods requires "requires_arc = ?" to be specified (despite the fact that FMDB can be used with or without ARC).
