### PR TITLE
Added cast to fix warning on 32-bit builds.

### DIFF
--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -293,7 +293,7 @@
     
     NSMutableData *data = [NSMutableData dataWithLength:(NSUInteger)dataSize];
     
-    memcpy([data mutableBytes], sqlite3_column_blob([_statement statement], columnIdx), dataSize);
+    memcpy([data mutableBytes], sqlite3_column_blob([_statement statement], columnIdx), (size_t)dataSize);
     
     return data;
 }


### PR DESCRIPTION
The call to memcpy in -dataForColumnIndex: was being passed an int (it accepts a size_t, ie: long on some platforms). This generated a warning in Xcode 5 when building (in my instance) for the iPad.
