### PR TITLE
Use `dataWithBytes` instead of `memcpy`

### DIFF
--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -290,12 +290,13 @@
     }
     
     int dataSize = sqlite3_column_bytes([_statement statement], columnIdx);
+    const char *dataBuffer = sqlite3_column_blob([_statement statement], columnIdx);
     
-    NSMutableData *data = [NSMutableData dataWithLength:(NSUInteger)dataSize];
+    if (dataBuffer == NULL) {
+        return nil;
+    }
     
-    memcpy([data mutableBytes], sqlite3_column_blob([_statement statement], columnIdx), (size_t)dataSize);
-    
-    return data;
+    return [NSData dataWithBytes:(const void *)dataBuffer length:(NSUInteger)dataSize];
 }
 
 


### PR DESCRIPTION
Pursuant to discussion on pull https://github.com/ccgus/fmdb/pull/271, I am submitting new pull request that eliminates `memcpy` function call from `dataForColumnIndex` method, and ensures that it returns non-mutable `NSData`. Gus, certainly feel free to use or disregard as you see fit.

BTW, I reviewed not only the [`NSData` documentation](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/Reference/Reference.html) method, but also empirically validated that `dataWithBytes` truly copies the buffer, rather than using it _in situ._

No additional test cases needed, as `testBlobs` seems to cover the bases.
