### PR TITLE
Adding support for NSUUID handler for any guid/uuid formed string

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -797,7 +797,10 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
             
             if (namedIdx > 0) {
                 // Standard binding from here.
-                [self bindObject:[dictionaryArgs objectForKey:dictionaryKey] toColumn:namedIdx inStatement:pStmt];
+                id obj = [dictionaryArgs objectForKey:dictionaryKey];
+                if ([obj isKindOfClass:[NSUUID class]])
+                    obj = [[((NSUUID*)obj) UUIDString] lowercaseString];
+                [self bindObject:obj toColumn:namedIdx inStatement:pStmt];
                 // increment the binding count, so our check below works out
                 idx++;
             }
@@ -812,9 +815,13 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
             
             if (arrayArgs && idx < (int)[arrayArgs count]) {
                 obj = [arrayArgs objectAtIndex:(NSUInteger)idx];
+                if ([obj isKindOfClass:[NSUUID class]])
+                    obj = [[((NSUUID*)obj) UUIDString] lowercaseString];
             }
             else if (args) {
                 obj = va_arg(args, id);
+                if ([obj isKindOfClass:[NSUUID class]])
+                    obj = [[((NSUUID*)obj) UUIDString] lowercaseString];
             }
             else {
                 //We ran out of arguments
@@ -978,7 +985,10 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
             
             if (namedIdx > 0) {
                 // Standard binding from here.
-                [self bindObject:[dictionaryArgs objectForKey:dictionaryKey] toColumn:namedIdx inStatement:pStmt];
+                id obj = [dictionaryArgs objectForKey:dictionaryKey];
+                if ([obj isKindOfClass:[NSUUID class]])
+                    obj = [[((NSUUID*)obj) UUIDString] lowercaseString];
+                [self bindObject:obj toColumn:namedIdx inStatement:pStmt];
                 
                 // increment the binding count, so our check below works out
                 idx++;
@@ -994,9 +1004,13 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
             
             if (arrayArgs && idx < (int)[arrayArgs count]) {
                 obj = [arrayArgs objectAtIndex:(NSUInteger)idx];
+                if ([obj isKindOfClass:[NSUUID class]])
+                    obj = [[((NSUUID*)obj) UUIDString] lowercaseString];
             }
             else if (args) {
                 obj = va_arg(args, id);
+                if ([obj isKindOfClass:[NSUUID class]])
+                    obj = [[((NSUUID*)obj) UUIDString] lowercaseString];
             }
             else {
                 //We ran out of arguments

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -402,6 +402,27 @@ If you don't, you're going to be in a world of hurt when you try and use the dat
 
 - (NSData*)dataNoCopyForColumnIndex:(int)columnIdx NS_RETURNS_NOT_RETAINED;
 
+/** Result set `NSUUID` value for column.
+ 
+ This is useful when storing unique identifier like GUID/UUID which usually used as primary key.
+ 
+ @param columnName `NSString` value of the name of the column.
+ 
+ @return `NSUUID` value of the result set's column.
+ 
+ */
+
+- (NSUUID*)uuidForColumn:(NSString*)columnName;
+
+/** Result set `NSUUID` value for column.
+ 
+ @param columnIdx Zero-based index for column.
+ 
+ @return `NSUUID` value of the result set's column.
+ */
+
+- (NSUUID*)uuidForColumnIndex:(int)columnIdx;
+
 /** Is the column `NULL`?
  
  @param columnIdx Zero-based index for column.

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -369,6 +369,28 @@
     return [self objectForColumnIndex:[self columnIndexForName:columnName]];
 }
 
+- (NSUUID*)uuidForColumnIndex:(int)columnIdx {
+    
+    if (sqlite3_column_type([_statement statement], columnIdx) == SQLITE_NULL || (columnIdx < 0)) {
+        return nil;
+    }
+    
+    const char *c = (const char *)sqlite3_column_text([_statement statement], columnIdx);
+    
+    if (!c) {
+        // null row.
+        return nil;
+    }
+    
+    NSUUID *result = nil;
+    @try { result = [[NSUUID alloc] initWithUUIDString:[NSString stringWithUTF8String:c]]; } @catch(NSException *ex) {}
+    return result;
+}
+
+- (NSUUID*)uuidForColumn:(NSString*)columnName {
+    return [self uuidForColumnIndex:[self columnIndexForName:columnName]];
+}
+
 // returns autoreleased NSString containing the name of the column in the result set
 - (NSString*)columnNameForIndex:(int)columnIdx {
     return [NSString stringWithUTF8String: sqlite3_column_name([_statement statement], columnIdx)];


### PR DESCRIPTION
Adding NSUUID conversion on executeUpdate and executeQuery on FMDatabase and uuidForColumn and uuidForColumnIndex on FMResultSet.

This is useful when the string data in the columns are guid-form. Most of my projects are using guid/uuid as primary keys which is not supported in sqlite and doing conversion back and forth between NSUUID and NSString is error-prone (since string data usually case sensitive which make equal uuid unequal just because they are written in different case).
