### PR TITLE
Fix CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF warnings

### DIFF
--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -108,10 +108,10 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 
 - (void)close {
     FMDBRetain(self);
-    dispatch_sync(_queue, ^() { 
-        [_db close];
+    dispatch_sync(_queue, ^() {
+        [self->_db close];
         FMDBRelease(_db);
-        _db = 0x00;
+        self->_db = 0x00;
     });
     FMDBRelease(self);
 }


### PR DESCRIPTION
When compiling with CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF enabled, the following warnings occur:

```
fmdb/src/fmdb/FMDatabaseQueue.m:112:10: Block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior
fmdb/src/fmdb/FMDatabaseQueue.m:114:9: Block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior
```

The attached pull request changes the implicit self reference to an explicit self reference to prevent this warning from occurring.
