### PR TITLE
Use correct tag version name

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
-  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => s.version.to_s }
+  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.4' }
   s.requires_arc = true
 
   s.default_subspec = 'standard'


### PR DESCRIPTION
@ccgus, I didn't realize that you use the 'v' in tag names ('v2.4' instead of '2.4'), so this change corrects the tag name in the fmdb podspec. 

Once this is merged, you'll need to delete the existing release & tag and recreate it. Sorry for the mistake!
