### PR TITLE
Use a weak `NSHashTable` for managing open result sets

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -86,7 +86,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
     NSTimeInterval      _startBusyRetryTime;
     
     NSMutableDictionary *_cachedStatements;
-    NSMutableSet        *_openResultSets;
+    NSHashTable         *_openResultSets;
     NSMutableSet        *_openFunctions;
 
     NSDateFormatter     *_dateFormat;

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -2,11 +2,6 @@
 #import "FMDatabase.h"
 #import "unistd.h"
 
-@interface FMDatabase ()
-- (void)resultSetDidClose:(FMResultSet *)resultSet;
-@end
-
-
 @implementation FMResultSet
 @synthesize query=_query;
 @synthesize statement=_statement;
@@ -47,10 +42,6 @@
     [_statement reset];
     FMDBRelease(_statement);
     _statement = nil;
-    
-    // we don't need this anymore... (i think)
-    //[_parentDB setInUse:NO];
-    [_parentDB resultSetDidClose:self];
     _parentDB = nil;
 }
 


### PR DESCRIPTION
This change replaces the use of an `NSMutableSet` containing `NSValue` references for managing open `FMResultSet` objects. This eliminates the potential for crashes due to over-releasing result sets.
