### PR TITLE
Changed NSNumber to NSDecimalNumber when retrieving doubles from db

### DIFF
--- a/src/FMResultSet.m
+++ b/src/FMResultSet.m
@@ -371,7 +371,7 @@
         returnValue = [NSNumber numberWithLongLong:[self longLongIntForColumnIndex:columnIdx]];
     }
     else if (columnType == SQLITE_FLOAT) {
-        returnValue = [NSNumber numberWithDouble:[self doubleForColumnIndex:columnIdx]];
+        returnValue = [NSDecimalNumber numberWithDouble:[self doubleForColumnIndex:columnIdx]];
     }
     else if (columnType == SQLITE_BLOB) {
         returnValue = [self dataForColumnIndex:columnIdx];


### PR DESCRIPTION
This will allow for better precision = less rounding errors.
