### PR TITLE
Add jitter to SQLite Busy handler

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -231,7 +231,11 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
     NSTimeInterval delta = [NSDate timeIntervalSinceReferenceDate] - (self->_startBusyRetryTime);
     
     if (delta < [self maxBusyRetryTimeInterval]) {
-        sqlite3_sleep(50); // milliseconds
+        int requestedSleepInMillseconds = arc4random_uniform(50) + 50;
+        int actualSleepInMilliseconds = sqlite3_sleep(requestedSleepInMillseconds);
+        if (actualSleepInMilliseconds != requestedSleepInMillseconds) {
+            NSLog(@"WARNING: Requested sleep of %i milliseconds, but SQLite returned %i. Maybe SQLite wasn't built with HAVE_USLEEP=1?", requestedSleepInMillseconds, actualSleepInMilliseconds);
+        }
         return 1;
     }
     


### PR DESCRIPTION
This patch makes a few small enhancements to the busy handler:
1. It applies a variable jitter on the sleep time between 50 and 100 milliseconds. This will space out retries if you have a bunch of concurrent reads blocking on a write.
2. It checks that `sqlite3_sleep` returned the save value that was passed in and emits a warning if they don’t match. If you are building SQLite yourself and fail to set `-DHAVE_USLEEP=1` then you wind up sleeping for a full second.
