### PR TITLE
Fixes wrong handling of sqlite3_column_bytes(...).

### DIFF
--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -314,9 +314,9 @@
         return nil;
     }
     
-    int dataSize = sqlite3_column_bytes([_statement statement], columnIdx);
     const char *dataBuffer = sqlite3_column_blob([_statement statement], columnIdx);
-    
+    int dataSize = sqlite3_column_bytes([_statement statement], columnIdx);
+
     if (dataBuffer == NULL) {
         return nil;
     }
@@ -334,10 +334,11 @@
     if (sqlite3_column_type([_statement statement], columnIdx) == SQLITE_NULL || (columnIdx < 0)) {
         return nil;
     }
-    
+  
+    const char *dataBuffer = sqlite3_column_blob([_statement statement], columnIdx);
     int dataSize = sqlite3_column_bytes([_statement statement], columnIdx);
     
-    NSData *data = [NSData dataWithBytesNoCopy:(void *)sqlite3_column_blob([_statement statement], columnIdx) length:(NSUInteger)dataSize freeWhenDone:NO];
+    NSData *data = [NSData dataWithBytesNoCopy:(void *)dataBuffer length:(NSUInteger)dataSize freeWhenDone:NO];
     
     return data;
 }


### PR DESCRIPTION
According to the official documentation of SQLite the order in which you call sqlite3_column_bytes and sqlite3_column_blob (and the related methods to retrieve the stored value) is important:

"In other words, you should call sqlite3_column_text(), sqlite3_column_blob(), or sqlite3_column_text16() first to force the result into the desired format, then invoke sqlite3_column_bytes() or sqlite3_column_bytes16() to find the size of the result. Do not mix calls to sqlite3_column_text() or sqlite3_column_blob() with calls to sqlite3_column_bytes16(), and do not mix calls to sqlite3_column_text16() with calls to sqlite3_column_bytes()."

This commit simply changes the order of those calls to conform to the official documentation.
