### PR TITLE
Don't force custom tokenizer module name

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.4.1'
+  s.version = '2.5'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
-  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.4.1' }
+  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.5' }
   s.requires_arc = true
 
   s.default_subspec = 'standard'

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.4'
+  s.version = '2.4.1'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
-  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.4' }
+  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.4.1' }
   s.requires_arc = true
 
   s.default_subspec = 'standard'

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		CCC24EC20A13E34D00A6D3E3 /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */; };
 		CCC24EC50A13E34D00A6D3E3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBE0A13E34D00A6D3E3 /* main.m */; };
 		CCC24EC70A13E34D00A6D3E3 /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; };
+		D4A740A21A7046330058EBEE /* FMDatabaseFTS3WithModuleNameTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D4A740A11A7046330058EBEE /* FMDatabaseFTS3WithModuleNameTests.m */; };
 		EE42910512B42FBC0088BD94 /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */; };
 		EE42910612B42FC30088BD94 /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC50F2CC0DF9183600E4AAAE /* FMDatabaseAdditions.h */; };
 		EE42910712B42FC90088BD94 /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -133,6 +134,7 @@
 		CCC24EBE0A13E34D00A6D3E3 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = src/sample/main.m; sourceTree = SOURCE_ROOT; };
 		CCC24EBF0A13E34D00A6D3E3 /* FMResultSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FMResultSet.h; path = src/fmdb/FMResultSet.h; sourceTree = SOURCE_ROOT; };
 		CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FMResultSet.m; path = src/fmdb/FMResultSet.m; sourceTree = SOURCE_ROOT; };
+		D4A740A11A7046330058EBEE /* FMDatabaseFTS3WithModuleNameTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMDatabaseFTS3WithModuleNameTests.m; sourceTree = "<group>"; };
 		EE4290EF12B42F870088BD94 /* libFMDB.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFMDB.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE42910C12B42FFA0088BD94 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -297,6 +299,7 @@
 			children = (
 				BF940F5D18417DEA0001E077 /* FMDatabaseAdditionsTests.m */,
 				67CB1E2F19AD27D000A3CA7F /* FMDatabaseFTS3Tests.m */,
+				D4A740A11A7046330058EBEE /* FMDatabaseFTS3WithModuleNameTests.m */,
 				BFE55E121841C9A000CB3A63 /* FMDatabasePoolTests.m */,
 				BFE55E141841D38800CB3A63 /* FMDatabaseQueueTests.m */,
 				BF5D042018416BB2008C5AA9 /* FMDatabaseTests.m */,
@@ -514,6 +517,7 @@
 				67CB1E3019AD27D000A3CA7F /* FMDatabaseFTS3Tests.m in Sources */,
 				BFE55E131841C9A000CB3A63 /* FMDatabasePoolTests.m in Sources */,
 				BFE55E151841D38800CB3A63 /* FMDatabaseQueueTests.m in Sources */,
+				D4A740A21A7046330058EBEE /* FMDatabaseFTS3WithModuleNameTests.m in Sources */,
 				CCA66A2E19C0CB1900EFDAC1 /* FMDatabase+FTS3.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/extra/fts3/FMDatabase+FTS3.h
+++ b/src/extra/fts3/FMDatabase+FTS3.h
@@ -25,15 +25,25 @@ extern NSString *const kFTSCommandAutoMerge;       // "automerge=%u"
 @interface FMDatabase (FTS3)
 
 /**
- Register a delgate implementation in the global table. The name should be used
- as a parameter when creating the table.
+ Register a delegate implementation in the global table. This should be used when using a single tokenizer.
  */
-+ (void)registerTokenizer:(id<FMTokenizerDelegate>)tokenizer withName:(NSString *)name;
++ (void)registerTokenizer:(id<FMTokenizerDelegate>)tokenizer;
 
 /**
- Calls the `fts3_tokenizer()` function on this database, installing the "fmdb" tokenizer module.
+ Register a delegate implementation in the global table. The key should be used
+ as a parameter when creating the table.
+ */
++ (void)registerTokenizer:(id<FMTokenizerDelegate>)tokenizer withKey:(NSString *)key;
+
+/**
+ Calls the `fts3_tokenizer()` function on this database, installing tokenizer module with the 'fmdb' name.
  */
 - (BOOL)installTokenizerModule;
+
+/**
+ Calls the `fts3_tokenizer()` function on this database, installing the tokenizer module with specified name.
+ */
+- (BOOL)installTokenizerModuleWithName:(NSString *)name;
 
 /**
  Runs a "special command" for FTS3/FTS4 tables.


### PR DESCRIPTION
Most of the time when using FTS, you'll only need to use a single tokenizer. This change simplifies using a single tokenizer.

@newyankeecodeshop, could you check this out as well?