### PR TITLE
Correct reported FMDB version

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -67,12 +67,12 @@
 }
 
 + (NSString*)FMDBUserVersion {
-    return @"2.3";
+    return @"2.4";
 }
 
-// returns 0x0230 for version 2.3.  This makes it super easy to do things like:
-// /* need to make sure to do X with FMDB version 2.3 or later */
-// if ([FMDatabase FMDBVersion] >= 0x0230) { … }
+// returns 0x0240 for version 2.4.  This makes it super easy to do things like:
+// /* need to make sure to do X with FMDB version 2.4 or later */
+// if ([FMDatabase FMDBVersion] >= 0x0240) { … }
 
 + (SInt32)FMDBVersion {
     


### PR DESCRIPTION
`[FMDatabase FMDBUserVersion]` still reported `2.3` instead of `2.4` as specified in the podspec.