### PR TITLE
Updated podspec version to prepare for v2.5 tag

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.4'
+  s.version = '2.5'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
-  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.4' }
+  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.5' }
   s.requires_arc = true
 
   s.default_subspec = 'standard'


### PR DESCRIPTION
Any chance you'd be willing to create a new tag version with the changes in master? We need to create a new CocoaPod version of FMDB for people to have access to everything that's changed since last September.

Here's the list of changes since v2.4:

* Cleanup
* Correct reported FMDB version
* Don't force custom tokenizer module name
* Quick fix, thanks to @kangchuh
* Fixes wrong handling of sqlite3_column_bytes(...).
	According to the official documentation of SQLite the order in which you call sqlite3_column_bytes and sqlite3_column_blob (and the related methods to retrieve the stored value) is important:
	"In other words, you should call sqlite3_column_text(), sqlite3_column_blob(), or sqlite3_column_text16() first to force the result into the desired format, then invoke sqlite3_column_bytes() or sqlite3_column_bytes16() to find the size of the result. Do not mix calls to sqlite3_column_text() or sqlite3_column_blob() with calls to sqlite3_column_bytes16(), and do not mix calls to sqlite3_column_text16() with calls to sqlite3_column_bytes()."
	This commit simply changes the order of those calls to conform to the official documentation.
* Add jitter to SQLite Busy handler
* Removed some inaccuracies from the docs.
* Updated license.
* Cleanup and sdk fixes.
* Fix for Xcode 6.1
* Swift instructions
* Modified extras
	Added `FMDatabaseVariadic` Swift extension for FMDatabase.
	Moved InMemoryOnDiskIO
* Add Swift extension
	Added extension for variadic renditions of `executeUpdate` and `executeQuery`.
* Adding 'nextWithError' method to FMResultSet to obtain error details
* Removed an unneeded newline in multiple statements code block
* Updated CocoaPods section of README and also trimmed whitespace
* Bump version in README.markdown