### PR TITLE
Create variadic renditions of the FMDatabaseAdditions methods

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -3,6 +3,9 @@ Zip, nada, zilch.  Got any ideas?
 
 If you would like to contribute some code- awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add a couple of tests for your new code to fmdb.m.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
 
+2015.01.23
+    Added Swift renditions of the variadic methods of FMDatabaseAdditions.
+
 2014.09.10
     New classes for exposing SQLite's FTS features.  Thanks to Andrew Goodale for the code.
 

--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -50,11 +50,11 @@ If you would like to contribute some code- awesome!  I just ask that you make it
 2013.06.04
     Merged in Robert Ryan's comments in .h header files. These comments hopefully make the .h more readable, but just as importantly, can be parsed by [`appledoc`](http://gentlebytes.com/appledoc/) to create HTML documentation or Xcode docsets. <https://github.com/ccgus/fmdb/pull/150>
 
-        - To build that HTML documentation, once you've installed `appledoc`, you issue the command:
+        - To build that HTML documentation, once you've installed `appledoc`, you issue the command [note Jan 2015: the `no-create-docset` needed due to recent changes to `appledoc`]:
 
-             appledoc --project-name FMDB --project-company ccgus --explicit-crossref --no-merge-categories --output ../Documentation --ignore *.m .
+             appledoc --project-name FMDB --project-company ccgus --explicit-crossref --no-merge-categories --no-create-docset --output ../Documentation --ignore *.m .
 
-        - If you want online help integrated right into Xcode, you can issue the command:
+        - If you want online help integrated right into Xcode (which is no longer needed because Xcode now automatically integrates documentation found in the .h files), you can issue the command:
 
              appledoc --project-name FMDB --project-company ccgus --explicit-crossref --merge-categories --install-docset --output --ignore *.m ../Documentation .
 

--- a/Tests/FMDatabaseAdditionsTests.m
+++ b/Tests/FMDatabaseAdditionsTests.m
@@ -101,4 +101,23 @@
     XCTAssertTrue([[self db] userVersion] == 12);
 }
 
+#if SQLITE_VERSION_NUMBER >= 3007017
+- (void)testApplicationID
+{
+    uint32_t appID = NSHFSTypeCodeFromFileType(NSFileTypeForHFSTypeCode('fmdb'));
+    
+    [self.db setApplicationID:appID];
+    
+    uint32_t rAppID = [self.db applicationID];
+    
+    XCTAssertEqual(rAppID, appID);
+    
+    [self.db setApplicationIDString:@"acrn"];
+    
+    NSString *s = [self.db applicationIDString];
+    
+    XCTAssertEqualObjects(s, @"acrn");
+}
+#endif
+
 @end

--- a/Tests/FMDatabaseTests.m
+++ b/Tests/FMDatabaseTests.m
@@ -812,26 +812,6 @@
 
 }
 
-
-#if SQLITE_VERSION_NUMBER >= 3007017
-- (void)testApplicationID
-{
-    uint32_t appID = NSHFSTypeCodeFromFileType(NSFileTypeForHFSTypeCode('fmdb'));
-    
-    [self.db setApplicationID:appID];
-    
-    uint32_t rAppID = [self.db applicationID];
-    
-    XCTAssertEqual(rAppID, appID);
-    
-    [self.db setApplicationIDString:@"acrn"];
-    
-    NSString *s = [self.db applicationIDString];
-    
-    XCTAssertEqualObjects(s, @"acrn");
-}
-#endif
-
 - (void)testVersionNumber {
     XCTAssertTrue([FMDatabase FMDBVersion] == 0x0230); // this is going to break everytime we bump it.
 }

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		8314AF3218CD73D600EC0E25 /* FMDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FMDB.h; path = src/fmdb/FMDB.h; sourceTree = "<group>"; };
 		831DE6FD175B7C9C001F7317 /* README.markdown */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.markdown; sourceTree = "<group>"; };
 		832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FMDatabaseVariadic.swift; path = "src/extra/Swift extensions/FMDatabaseVariadic.swift"; sourceTree = "<group>"; };
+		8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FMDatabaseAdditionsVariadic.swift; path = "src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift"; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* fmdb */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fmdb; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF5D041618416BB2008C5AA9 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF5D041818416BB2008C5AA9 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -267,6 +268,7 @@
 			isa = PBXGroup;
 			children = (
 				832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */,
+				8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */,
 			);
 			name = "Swift extensions";
 			sourceTree = "<group>";
@@ -428,7 +430,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0610;
 				TargetAttributes = {
 					BF5D041518416BB2008C5AA9 = {
 						TestTargetID = EE4290EE12B42F870088BD94;
@@ -595,7 +597,9 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -619,7 +623,9 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -634,7 +640,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -665,7 +670,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
@@ -20,7 +20,10 @@ extension FMDatabase {
         
         if let rs = executeQuery(sql, withArgumentsInArray: values) {
             if rs.next() {
-                result = completionHandler(rs)
+                let obj = rs.objectForColumnIndex(0) as NSObject
+                if !(obj is NSNull) {
+                    result = completionHandler(rs)
+                }
             }
             rs.close()
         }

--- a/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
@@ -1,0 +1,114 @@
+//
+//  FMDatabaseAdditionsVariadic.swift
+//  FMDB
+//
+
+import Foundation
+
+extension FMDatabase {
+    
+    /// Private generic function used for the variadic renditions of the FMDatabaseAdditions methods
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The NSArray of the arguments to be bound to the ? placeholders in the SQL.
+    /// :param: completionHandler The closure to be used to call the appropriate FMDatabase method to return the desired value.
+    ///
+    /// :returns: This returns the T value if value is found. Returns nil if column is NULL or upon error.
+    
+    private func valueForQuery<T>(sql: String, values: NSArray?, completionHandler:(FMResultSet)->(T!)) -> T! {
+        var result: T!
+        
+        if let rs = executeQuery(sql, withArgumentsInArray: values) {
+            if rs.next() {
+                result = completionHandler(rs)
+            }
+            rs.close()
+        }
+        
+        return result
+    }
+    
+    /// This is a rendition of stringForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns string value if value is found. Returns nil if column is NULL or upon error.
+    
+    func stringForQuery(sql: String, _ values: AnyObject...) -> String! {
+        return valueForQuery(sql, values: values as NSArray) { $0.stringForColumnIndex(0) }
+    }
+    
+    /// This is a rendition of intForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns integer value if value is found. Returns nil if column is NULL or upon error.
+    
+    func intForQuery(sql: String, _ values: AnyObject...) -> Int32! {
+        return valueForQuery(sql, values: values as NSArray) { $0.intForColumnIndex(0) }
+    }
+    
+    /// This is a rendition of longForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns long value if value is found. Returns nil if column is NULL or upon error.
+    
+    func longForQuery(sql: String, _ values: AnyObject...) -> Int! {
+        return valueForQuery(sql, values: values as NSArray) { $0.longForColumnIndex(0) }
+    }
+    
+    /// This is a rendition of boolForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns Bool value if value is found. Returns nil if column is NULL or upon error.
+    
+    func boolForQuery(sql: String, _ values: AnyObject...) -> Bool! {
+        return valueForQuery(sql, values: values as NSArray) { $0.boolForColumnIndex(0) }
+    }
+    
+    /// This is a rendition of doubleForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns Double value if value is found. Returns nil if column is NULL or upon error.
+    
+    func doubleForQuery(sql: String, _ values: AnyObject...) -> Double! {
+        return valueForQuery(sql, values: values as NSArray) { $0.doubleForColumnIndex(0) }
+    }
+    
+    /// This is a rendition of dateForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns NSDate value if value is found. Returns nil if column is NULL or upon error.
+    
+    func dateForQuery(sql: String, _ values: AnyObject...) -> NSDate! {
+        return valueForQuery(sql, values: values as NSArray) { $0.dateForColumnIndex(0) }
+    }
+    
+    /// This is a rendition of dataForQuery that handles Swift variadic parameters
+    /// for the values to be bound to the ? placeholders in the SQL.
+    ///
+    /// :param: sql The SQL statement to be used.
+    /// :param: values The values to be bound to the ? placeholders
+    ///
+    /// :returns: This returns NSData value if value is found. Returns nil if column is NULL or upon error.
+    
+    func dataForQuery(sql: String, _ values: AnyObject...) -> NSData! {
+        return valueForQuery(sql, values: values as NSArray) { $0.dataForColumnIndex(0) }
+    }
+}

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -298,6 +298,8 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  @see [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html)
  
  @note This technique supports the use of `?` placeholders in the SQL, automatically binding any supplied value parameters to those placeholders. This approach is more robust than techniques that entail using `stringWithFormat` to manually build SQL statements, which can be problematic if the values happened to include any characters that needed to be quoted.
+ 
+ @note If you want to use this from Swift, please note that you must include `FMDatabaseVariadic.swift` in your project. Without that, you cannot use this method directly, and instead have to use methods such as `<executeUpdate:withArgumentsInArray:>`.
  */
 
 - (BOOL)executeUpdate:(NSString*)sql, ...;
@@ -500,6 +502,8 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
     [db executeQuery:@"SELECT * FROM test WHERE name=?", @"Gus"];
  
  There are two reasons why this distinction is important. First, the printf-style escape sequences can only be used where it is permissible to use a SQLite `?` placeholder. You can use it only for values in SQL statements, but not for table names or column names or any other non-value context. This method also cannot be used in conjunction with `pragma` statements and the like. Second, note the lack of quotation marks in the SQL. The `WHERE` clause was _not_ `WHERE name='%@'` (like you might have to do if you built a SQL statement using `NSString` method `stringWithFormat`), but rather simply `WHERE name=%@`.
+ 
+ @note If you want to use this from Swift, please note that you must include `FMDatabaseVariadic.swift` in your project. Without that, you cannot use this method directly, and instead have to use methods such as `<executeQuery:withArgumentsInArray:>`.
 
  */
 

--- a/src/fmdb/FMDatabaseAdditions.h
+++ b/src/fmdb/FMDatabaseAdditions.h
@@ -29,6 +29,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `int` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (int)intForQuery:(NSString*)query, ...;
@@ -39,6 +41,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `long` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (long)longForQuery:(NSString*)query, ...;
@@ -49,6 +53,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `BOOL` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (BOOL)boolForQuery:(NSString*)query, ...;
@@ -59,6 +65,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `double` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (double)doubleForQuery:(NSString*)query, ...;
@@ -69,6 +77,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `NSString` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (NSString*)stringForQuery:(NSString*)query, ...;
@@ -79,6 +89,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `NSData` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (NSData*)dataForQuery:(NSString*)query, ...;
@@ -89,6 +101,8 @@
  @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `NSDate` value.
+ 
+ @note To use this method from Swift, you must include `FMDatabaseAdditionsVariadic.swift` in your project.
  */
 
 - (NSDate*)dateForQuery:(NSString*)query, ...;


### PR DESCRIPTION
This is an extension that adds the variadic methods within the Objective-C FMDatabaseAdditions extension.

This addresses the problem identified in issue https://github.com/ccgus/fmdb/issues/336. 

Gus, I wasn't sure about the file name (it's getting a little unwieldy), but I wanted to conform to established patterns. Perhaps a shorter name would be better.

Also, it's worth noting that these methods return implicitly unwrapped optionals. This is a solid Swift pattern, but deviates a little from the Objective-C convention (for fundamental data types such as `int`, `double`, etc., at least). We could return non-optional values for those types if you wanted, but it feels like that's a step in the wrong direction (i.e. the Swift optional lets you differentiate between a `nil` value from `intForQuery` and a zero value).