### PR TITLE
Adding SQLITE_OPEN_URI flag

### DIFF
--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -84,7 +84,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 - (instancetype)initWithPath:(NSString*)aPath {
     
     // default flags for sqlite3_open
-    return [self initWithPath:aPath flags:SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE];
+    return [self initWithPath:aPath flags:SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI];
 }
 
 - (instancetype)init {


### PR DESCRIPTION
I've updated my SQLite version (as now I need to use SQLCipher), but I was surprised that `FMDatabaseQueue`'s `init`s and `databaseQueueWithPath:` started returning `nil`, because `sqlite3_open_v2` started returning `SQLITE_CANTOPEN`.

Adding `SQLITE_OPEN_URI` to the flags resolved the issue. I know that I can use `initWithPath:flags:`, but I think most people won't realize that this is needed.