### PR TITLE
Modified to support using framework

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'common' do |ss|
     ss.source_files = 'src/fmdb/FM*.{h,m}'
+    ss.private_header_files = 'src/fmdb/*Private.h'
     ss.exclude_files = 'src/fmdb.m'
   end
 

--- a/Tests/FMDatabaseQueueTests.m
+++ b/Tests/FMDatabaseQueueTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "FMDatabaseQueue.h"
+#import <sqlite3.h>
 
 @interface FMDatabaseQueueTests : FMDBTempDBTests
 

--- a/Tests/FMDatabaseTests.m
+++ b/Tests/FMDatabaseTests.m
@@ -9,6 +9,7 @@
 #import "FMDBTempDBTests.h"
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"
+#import <sqlite3.h>
 
 @interface FMDatabaseTests : FMDBTempDBTests
 
@@ -785,7 +786,7 @@
     [self.db executeUpdate:@"insert into ftest values ('not h!')"];
     [self.db executeUpdate:@"insert into ftest values ('definitely not h!')"];
     
-    [self.db makeFunctionNamed:@"StringStartsWithH" maximumArguments:1 withBlock:^(sqlite3_context *context, int aargc, sqlite3_value **aargv) {
+    [self.db makeFunctionNamed:@"StringStartsWithH" maximumArguments:1 withBlock:^(void *context, int aargc, void **aargv) {
         if (sqlite3_value_type(aargv[0]) == SQLITE_TEXT) {
             
             @autoreleasepool {

--- a/Tests/FMResultSetTests.m
+++ b/Tests/FMResultSetTests.m
@@ -9,6 +9,7 @@
 #import "FMDBTempDBTests.h"
 #import "FMDatabase.h"
 #import "FMResultSet.h"
+#import <sqlite3.h>
 
 @interface FMResultSetTests : FMDBTempDBTests
 

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		8314AF3218CD73D600EC0E25 /* FMDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FMDB.h; path = src/fmdb/FMDB.h; sourceTree = "<group>"; };
 		831DE6FD175B7C9C001F7317 /* README.markdown */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.markdown; sourceTree = "<group>"; };
 		832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FMDatabaseVariadic.swift; path = "src/extra/Swift extensions/FMDatabaseVariadic.swift"; sourceTree = "<group>"; };
+		8342E80C1AC72F3B003D3921 /* FMDatabasePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FMDatabasePrivate.h; path = src/fmdb/FMDatabasePrivate.h; sourceTree = "<group>"; };
 		8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FMDatabaseAdditionsVariadic.swift; path = "src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift"; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* fmdb */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fmdb; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF5D041618416BB2008C5AA9 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -245,6 +246,7 @@
 			isa = PBXGroup;
 			children = (
 				8314AF3218CD73D600EC0E25 /* FMDB.h */,
+				8342E80C1AC72F3B003D3921 /* FMDatabasePrivate.h */,
 				CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */,
 				CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */,
 				CCC24EBF0A13E34D00A6D3E3 /* FMResultSet.h */,
@@ -436,7 +438,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0620;
 				TargetAttributes = {
 					BF5D041518416BB2008C5AA9 = {
 						TestTargetID = EE4290EE12B42F870088BD94;
@@ -620,7 +622,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -642,7 +644,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -738,7 +740,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -773,7 +775,7 @@
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
+++ b/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
@@ -1,4 +1,5 @@
 #import "FMDatabase+InMemoryOnDiskIO.h"
+#import "FMDatabasePrivate.h"
 
 // http://www.sqlite.org/backup.html
 static
@@ -63,13 +64,13 @@ int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
     }
     
     // and only if the database is open
-    if ( self->_db == nil ) 
+    if ( self.db == nil )
     {
         NSLog(@"Invalid database connection." );
         return NO;
     }
     
-    return ( SQLITE_OK == loadOrSaveDb( self->_db, [filePath fileSystemRepresentation], false ) );
+    return ( SQLITE_OK == loadOrSaveDb( self.db, [filePath fileSystemRepresentation], false ) );
 
 }
 
@@ -83,14 +84,14 @@ int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
     }
     
     // and only if the database is open
-    if ( self->_db == nil ) 
+    if ( self.db == nil )
     {
         NSLog(@"Invalid database connection." );
         return NO;
     }
     
     // save the in-memory representation    
-    return ( SQLITE_OK == loadOrSaveDb( self->_db, [filePath fileSystemRepresentation], true ) );
+    return ( SQLITE_OK == loadOrSaveDb( self.db, [filePath fileSystemRepresentation], true ) );
 }
 
 @end

--- a/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
@@ -15,12 +15,12 @@ extension FMDatabase {
     ///
     /// :returns: This returns the T value if value is found. Returns nil if column is NULL or upon error.
     
-    private func valueForQuery<T>(sql: String, values: NSArray?, completionHandler:(FMResultSet)->(T!)) -> T! {
+    private func valueForQuery<T>(sql: String, values: [AnyObject]?, completionHandler:(FMResultSet)->(T!)) -> T! {
         var result: T!
         
         if let rs = executeQuery(sql, withArgumentsInArray: values) {
             if rs.next() {
-                let obj = rs.objectForColumnIndex(0) as NSObject
+                let obj: AnyObject! = rs.objectForColumnIndex(0) // as NSObject
                 if !(obj is NSNull) {
                     result = completionHandler(rs)
                 }
@@ -40,7 +40,7 @@ extension FMDatabase {
     /// :returns: This returns string value if value is found. Returns nil if column is NULL or upon error.
     
     func stringForQuery(sql: String, _ values: AnyObject...) -> String! {
-        return valueForQuery(sql, values: values as NSArray) { $0.stringForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.stringForColumnIndex(0) }
     }
     
     /// This is a rendition of intForQuery that handles Swift variadic parameters
@@ -52,7 +52,7 @@ extension FMDatabase {
     /// :returns: This returns integer value if value is found. Returns nil if column is NULL or upon error.
     
     func intForQuery(sql: String, _ values: AnyObject...) -> Int32! {
-        return valueForQuery(sql, values: values as NSArray) { $0.intForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.intForColumnIndex(0) }
     }
     
     /// This is a rendition of longForQuery that handles Swift variadic parameters
@@ -64,7 +64,7 @@ extension FMDatabase {
     /// :returns: This returns long value if value is found. Returns nil if column is NULL or upon error.
     
     func longForQuery(sql: String, _ values: AnyObject...) -> Int! {
-        return valueForQuery(sql, values: values as NSArray) { $0.longForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.longForColumnIndex(0) }
     }
     
     /// This is a rendition of boolForQuery that handles Swift variadic parameters
@@ -76,7 +76,7 @@ extension FMDatabase {
     /// :returns: This returns Bool value if value is found. Returns nil if column is NULL or upon error.
     
     func boolForQuery(sql: String, _ values: AnyObject...) -> Bool! {
-        return valueForQuery(sql, values: values as NSArray) { $0.boolForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.boolForColumnIndex(0) }
     }
     
     /// This is a rendition of doubleForQuery that handles Swift variadic parameters
@@ -88,7 +88,7 @@ extension FMDatabase {
     /// :returns: This returns Double value if value is found. Returns nil if column is NULL or upon error.
     
     func doubleForQuery(sql: String, _ values: AnyObject...) -> Double! {
-        return valueForQuery(sql, values: values as NSArray) { $0.doubleForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.doubleForColumnIndex(0) }
     }
     
     /// This is a rendition of dateForQuery that handles Swift variadic parameters
@@ -100,7 +100,7 @@ extension FMDatabase {
     /// :returns: This returns NSDate value if value is found. Returns nil if column is NULL or upon error.
     
     func dateForQuery(sql: String, _ values: AnyObject...) -> NSDate! {
-        return valueForQuery(sql, values: values as NSArray) { $0.dateForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.dateForColumnIndex(0) }
     }
     
     /// This is a rendition of dataForQuery that handles Swift variadic parameters
@@ -112,6 +112,6 @@ extension FMDatabase {
     /// :returns: This returns NSData value if value is found. Returns nil if column is NULL or upon error.
     
     func dataForQuery(sql: String, _ values: AnyObject...) -> NSData! {
-        return valueForQuery(sql, values: values as NSArray) { $0.dataForColumnIndex(0) }
+        return valueForQuery(sql, values: values) { $0.dataForColumnIndex(0) }
     }
 }

--- a/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
@@ -20,7 +20,7 @@ extension FMDatabase {
         
         if let rs = executeQuery(sql, withArgumentsInArray: values) {
             if rs.next() {
-                let obj: AnyObject! = rs.objectForColumnIndex(0) // as NSObject
+                let obj: AnyObject! = rs.objectForColumnIndex(0)
                 if !(obj is NSNull) {
                     result = completionHandler(rs)
                 }

--- a/src/extra/Swift extensions/FMDatabaseVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseVariadic.swift
@@ -19,7 +19,7 @@ extension FMDatabase {
     /// :returns: This returns FMResultSet if successful. Returns nil upon error.
 
     func executeQuery(sql:String, _ values: AnyObject...) -> FMResultSet? {
-        return executeQuery(sql, withArgumentsInArray: values as NSArray);
+        return executeQuery(sql, withArgumentsInArray: values as [AnyObject]);
     }
 
     /// This is a rendition of executeUpdate that handles Swift variadic parameters
@@ -31,6 +31,6 @@ extension FMDatabase {
     /// :returns: This returns true if successful. Returns false upon error.
 
     func executeUpdate(sql:String, _ values: AnyObject...) -> Bool {
-        return executeUpdate(sql, withArgumentsInArray: values as NSArray);
+        return executeUpdate(sql, withArgumentsInArray: values as [AnyObject]);
     }
 }

--- a/src/extra/fts3/FMDatabase+FTS3.m
+++ b/src/extra/fts3/FMDatabase+FTS3.m
@@ -7,6 +7,7 @@
 //
 
 #import "FMDatabase+FTS3.h"
+#import "FMDatabasePrivate.h"
 #import "fts3_tokenizer.h"
 
 NSString *const kFTSCommandOptimize = @"optimize";

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
 #import "FMResultSet.h"
 #import "FMDatabasePool.h"
 
@@ -72,8 +71,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 
 
 @interface FMDatabase : NSObject  {
-    
-    sqlite3*            _db;
     NSString*           _databasePath;
     BOOL                _logsErrors;
     BOOL                _crashOnErrors;
@@ -212,14 +209,14 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  
  @return `YES` if successful, `NO` on error.
 
+ @notes In SQLite versions prior to 3.5, this simply calls `open` method.
+ 
  @see [sqlite3_open_v2()](http://sqlite.org/c3ref/open.html)
  @see open
  @see close
  */
 
-#if SQLITE_VERSION_NUMBER >= 3005000
 - (BOOL)openWithFlags:(int)flags;
-#endif
 
 /** Closing a database connection
  
@@ -437,7 +434,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 
  */
 
-- (sqlite_int64)lastInsertRowId;
+- (long long int)lastInsertRowId;
 
 /** The number of rows changed by prior SQL statement.
  
@@ -727,7 +724,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  
  */
 
-- (sqlite3*)sqliteHandle;
+- (void*)sqliteHandle;
 
 
 ///-----------------------------
@@ -791,8 +788,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 - (NSTimeInterval)maxBusyRetryTimeInterval;
 
 
-#if SQLITE_VERSION_NUMBER >= 3007000
-
 ///------------------
 /// @name Save points
 ///------------------
@@ -854,7 +849,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 
 - (NSError*)inSavePoint:(void (^)(BOOL *rollback))block;
 
-#endif
 
 ///----------------------------
 /// @name SQLite library status
@@ -932,7 +926,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  @see [sqlite3_create_function()](http://sqlite.org/c3ref/create_function.html)
  */
 
-- (void)makeFunctionNamed:(NSString*)name maximumArguments:(int)count withBlock:(void (^)(sqlite3_context *context, int argc, sqlite3_value **argv))block;
+- (void)makeFunctionNamed:(NSString*)name maximumArguments:(int)count withBlock:(void (^)(void *context, int argc, void **argv))block;
 
 
 ///---------------------
@@ -1036,7 +1030,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  */
 
 @interface FMStatement : NSObject {
-    sqlite3_stmt *_statement;
     NSString *_query;
     long _useCount;
     BOOL _inUse;
@@ -1053,13 +1046,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 /** SQL statement */
 
 @property (atomic, retain) NSString *query;
-
-/** SQLite sqlite3_stmt
- 
- @see [`sqlite3_stmt`](http://www.sqlite.org/c3ref/stmt.html)
- */
-
-@property (atomic, assign) sqlite3_stmt *statement;
 
 /** Indication of whether the statement is in use */
 

--- a/src/fmdb/FMDatabaseAdditions.h
+++ b/src/fmdb/FMDatabaseAdditions.h
@@ -209,8 +209,6 @@
 - (BOOL)validateSQL:(NSString*)sql error:(NSError**)error;
 
 
-#if SQLITE_VERSION_NUMBER >= 3007017
-
 ///-----------------------------------
 /// @name Application identifier tasks
 ///-----------------------------------
@@ -252,8 +250,6 @@
  */
 
 - (void)setApplicationIDString:(NSString*)string;
-#endif
-
 #endif
 
 ///-----------------------------------

--- a/src/fmdb/FMDatabaseAdditions.m
+++ b/src/fmdb/FMDatabaseAdditions.m
@@ -7,6 +7,7 @@
 //
 
 #import "FMDatabase.h"
+#import "FMDatabasePrivate.h"
 #import "FMDatabaseAdditions.h"
 #import "TargetConditionals.h"
 
@@ -118,9 +119,6 @@ return ret;
     return returnBool;
 }
 
-
-#if SQLITE_VERSION_NUMBER >= 3007017
-
 - (uint32_t)applicationID {
     
     uint32_t r = 0;
@@ -143,7 +141,6 @@ return ret;
     [rs close];
 }
 
-
 #if TARGET_OS_MAC && !TARGET_OS_IPHONE
 - (NSString*)applicationIDString {
     NSString *s = NSFileTypeForHFSTypeCode([self applicationID]);
@@ -152,9 +149,7 @@ return ret;
     
     s = [s substringWithRange:NSMakeRange(1, 4)];
     
-    
     return s;
-    
 }
 
 - (void)setApplicationIDString:(NSString*)s {
@@ -165,9 +160,6 @@ return ret;
     
     [self setApplicationID:NSHFSTypeCodeFromFileType([NSString stringWithFormat:@"'%@'", s])];
 }
-
-
-#endif
 
 #endif
 
@@ -205,7 +197,7 @@ return ret;
     sqlite3_stmt *pStmt = NULL;
     BOOL validationSucceeded = YES;
     
-    int rc = sqlite3_prepare_v2(_db, [sql UTF8String], -1, &pStmt, 0);
+    int rc = sqlite3_prepare_v2(self.db, [sql UTF8String], -1, &pStmt, 0);
     if (rc != SQLITE_OK) {
         validationSucceeded = NO;
         if (error) {

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
 
 @class FMDatabase;
 
@@ -156,8 +155,6 @@
 
 - (void)inDeferredTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
-#if SQLITE_VERSION_NUMBER >= 3007000
-
 /** Synchronously perform database operations in pool using save point.
 
  @param block The code to be run on the `FMDatabasePool` pool.
@@ -168,7 +165,6 @@
 */
 
 - (NSError*)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block;
-#endif
 
 @end
 

--- a/src/fmdb/FMDatabasePool.m
+++ b/src/fmdb/FMDatabasePool.m
@@ -8,6 +8,7 @@
 
 #import "FMDatabasePool.h"
 #import "FMDatabase.h"
+#import "FMDatabasePrivate.h"
 
 @interface FMDatabasePool()
 
@@ -127,11 +128,9 @@
         }
         
         //This ensures that the db is opened before returning
-#if SQLITE_VERSION_NUMBER >= 3005000
+
         BOOL success = [db openWithFlags:self->_openFlags];
-#else
-        BOOL success = [db open];
-#endif
+
         if (success) {
             if ([self->_delegate respondsToSelector:@selector(databasePool:shouldAddDatabaseToPool:)] && ![self->_delegate databasePool:self shouldAddDatabaseToPool:db]) {
                 [db close];

--- a/src/fmdb/FMDatabasePrivate.h
+++ b/src/fmdb/FMDatabasePrivate.h
@@ -1,0 +1,39 @@
+//
+//  FMDatabasePrivate.h
+//  fmdb
+//
+//  Created by Robert Ryan on 3/28/15.
+//
+//
+
+#ifndef fmdb_FMDatabasePrivate_h
+#define fmdb_FMDatabasePrivate_h
+
+#import <sqlite3.h>
+
+@class FMDatabase;
+@class FMStatement;
+
+@interface FMDatabase (Private)
+
+/** SQLite sqlite3
+ 
+ @see [`sqlite3`](http://www.sqlite.org/c3ref/sqlite3.html)
+ */
+
+@property (nonatomic, assign, readonly) sqlite3 *db;
+
+@end
+
+@interface FMStatement (Private)
+
+/** SQLite sqlite3_stmt
+ 
+ @see [`sqlite3_stmt`](http://www.sqlite.org/c3ref/stmt.html)
+ */
+
+@property (nonatomic, assign) sqlite3_stmt *statement;
+
+@end
+
+#endif

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
 
 @class FMDatabase;
 
@@ -164,11 +163,9 @@
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-#if SQLITE_VERSION_NUMBER >= 3007000
 // NOTE: you can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock.
 // If you need to nest, use FMDatabase's startSavePointWithName:error: instead.
 - (NSError*)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block;
-#endif
 
 @end
 

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -8,6 +8,7 @@
 
 #import "FMDatabaseQueue.h"
 #import "FMDatabase.h"
+#import "FMDatabasePrivate.h"
 
 /*
  

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
 
 #ifndef __has_feature      // Optional.
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -1,6 +1,7 @@
 #import "FMResultSet.h"
 #import "FMDatabase.h"
-#import "unistd.h"
+#import "FMDatabasePrivate.h"
+#import <unistd.h>
 
 @interface FMDatabase ()
 - (void)resultSetDidClose:(FMResultSet *)resultSet;

--- a/src/sample/main.m
+++ b/src/sample/main.m
@@ -5,6 +5,7 @@
 
 #import <Foundation/Foundation.h>
 #import "FMDB.h"
+#import <sqlite3.h>
 
 #define FMDBQuickCheck(SomeBool) { if (!(SomeBool)) { NSLog(@"Failure on line %d", __LINE__); abort(); } }
 
@@ -1045,7 +1046,7 @@ int main (int argc, const char * argv[]) {
         [adb executeUpdate:@"insert into ftest values ('not h!')"];
         [adb executeUpdate:@"insert into ftest values ('definitely not h!')"];
         
-        [adb makeFunctionNamed:@"StringStartsWithH" maximumArguments:1 withBlock:^(sqlite3_context *context, int aargc, sqlite3_value **aargv) {
+        [adb makeFunctionNamed:@"StringStartsWithH" maximumArguments:1 withBlock:^(void *context, int aargc, void **aargv) {
             if (sqlite3_value_type(aargv[0]) == SQLITE_TEXT) {
                 
                 @autoreleasepool {


### PR DESCRIPTION
To use FMDB in framework, one should eliminate all non-modular headers. The main culprit here is `#import <sqlite3.h>`. The thing is, FMDB uses SQLite types and constants in these headers, so they had to be removed.

1. Removed `#import <sqlite3.h>` from all of the headers.

2. Moved `sqlite3` and `sqlite3_stmt` declarations in `FMDatabase.h` into `FMDatabasePrivate.h`. FMDB source that needs these will now `#import "FMDatabasePrivate.h" and will have access to them.

3. Removed `#if SQLITE_VERSION_NUMBER >= xxx` logic from the headers.

4. `lastInsertRowId` now returns `long long int`, not `sqlite3_int64`.

5. `sqliteHandle` now returns `void *` not `sqlite3 *`.

6. The `savepoint` and `release savepoint` and `rollback` now always compile regardless of SQLite version (but you'll get SQLite errors if you try those commands with earlier SQLite versions).

7. `makeFunctionNamed` has changed the block parameter type.

8. The FMDatabaseAdditions routines for `applicationID`, much like the `savepoint` routines, will be compiled regardless of SQLite version.

9. Some random usage of deferencing ivars from another class have been replaced with accessor methods.

Note, with all of these changes, in order to conform to modular headers, this is not entirely backward compatible. They'll have to make changes if

 - If they referenced the `_db` variable themselves (which they shouldn't be doing anyway; this never should have been in the public interface to start with);

 - If they referenced `_statement` variable of `FMStatement` (which is even less likely); or

 - If they used `makeFunctionNamed`, the signature of the block has changed (now uses `void` instead of SQLite types).