### PR TITLE
Added async methods for FMDatabaseQueue

### DIFF
--- a/Tests/FMDatabaseQueueTests.m
+++ b/Tests/FMDatabaseQueueTests.m
@@ -62,6 +62,33 @@
     }];
 }
 
+- (void)testAsync
+{
+    XCTestExpectation *queueExpectation = [self expectationWithDescription:@"Async inDatabase operation"];
+    
+    [self.queue inDatabase:^(FMDatabase *adb) {
+        int count = 0;
+        FMResultSet *rsl = [adb executeQuery:@"select * from qfoo where foo like 'h%'"];
+        while ([rsl next]) {
+            count++;
+        }
+        
+        XCTAssertEqual(count, 2);
+        
+        count = 0;
+        rsl = [adb executeQuery:@"select * from qfoo where foo like ?", @"h%"];
+        while ([rsl next]) {
+            count++;
+        }
+        
+        XCTAssertEqual(count, 2);
+        
+        [queueExpectation fulfill];
+    } async:YES];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 - (void)testReadOnlyQueue
 {
     FMDatabaseQueue *queue2 = [FMDatabaseQueue databaseQueueWithPath:self.databasePath flags:SQLITE_OPEN_READONLY];

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -141,6 +141,14 @@
 
 - (void)inDatabase:(void (^)(FMDatabase *db))block;
 
+/** Perform database operations on queue.
+ 
+ @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param async When set to `YES`, this method will return immediately and the work will be done asynchronously.
+ */
+
+- (void)inDatabase:(void (^)(FMDatabase *db))block async:(BOOL)async;
+
 /** Synchronously perform database operations on queue, using transactions.
 
  @param block The code to be run on the queue of `FMDatabaseQueue`
@@ -148,12 +156,28 @@
 
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
+/** Perform database operations on queue, using transactions.
+ 
+ @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param async When set to `YES`, this method will return immediately and the work will be done asynchronously.
+ */
+
+- (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block async:(BOOL)async;
+
 /** Synchronously perform database operations on queue, using deferred transactions.
 
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
 - (void)inDeferredTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
+
+/** Perform database operations on queue, using deferred transactions.
+ 
+ @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param async When set to `YES`, this method will return immediately and the work will be done asynchronously.
+ */
+
+- (void)inDeferredTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block async:(BOOL)async;
 
 ///-----------------------------------------------
 /// @name Dispatching database operations to queue
@@ -168,6 +192,8 @@
 // NOTE: you can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock.
 // If you need to nest, use FMDatabase's startSavePointWithName:error: instead.
 - (NSError*)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block;
+
+- (void)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block async:(BOOL)async completion:(void(^)(NSError *error))completion;
 #endif
 
 @end


### PR DESCRIPTION
These new methods add the option to return immediately and perform the operations on the queue.

`- (void)inDatabase:(void (^)(FMDatabase *db))block async:(BOOL)async`
`- (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block async:(BOOL)async`
`- (void)inDeferredTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block async:(BOOL)async`
`- (void)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block async:(BOOL)async completion:(void(^)(NSError *error))completion`