### PR TITLE
Check if block parameter is not null (after Facebook Infer analyze)

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1315,8 +1315,9 @@ static NSString *FMDBEscapeSavePointName(NSString *savepointName) {
         return err;
     }
     
-	if (block)
-		block(&shouldRollback);
+    if (block) {
+        block(&shouldRollback);
+    }
     
     if (shouldRollback) {
         // We need to rollback and release this savepoint to remove it
@@ -1357,8 +1358,9 @@ void FMDBBlockSQLiteCallBackFunction(sqlite3_context *context, int argc, sqlite3
 #else
     void (^block)(sqlite3_context *context, int argc, sqlite3_value **argv) = (__bridge id)sqlite3_user_data(context);
 #endif
-	if (block)
-		block(context, argc, argv);
+    if (block) {
+        block(context, argc, argv);
+    }
 }
 
 

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1315,7 +1315,8 @@ static NSString *FMDBEscapeSavePointName(NSString *savepointName) {
         return err;
     }
     
-    block(&shouldRollback);
+	if (block)
+		block(&shouldRollback);
     
     if (shouldRollback) {
         // We need to rollback and release this savepoint to remove it
@@ -1356,7 +1357,8 @@ void FMDBBlockSQLiteCallBackFunction(sqlite3_context *context, int argc, sqlite3
 #else
     void (^block)(sqlite3_context *context, int argc, sqlite3_value **argv) = (__bridge id)sqlite3_user_data(context);
 #endif
-    block(context, argc, argv);
+	if (block)
+		block(context, argc, argv);
 }
 
 


### PR DESCRIPTION
I use `FMDatabase` in many iOS applications and I've analyzed my projects with Facebook Infer (http://fbinfer.com/). The analyze returned two warnings with `block` parameters that could be null.

This little commit just check if `block` variable is not null before calling it.