### PR TITLE
Replace deprecated unicode61 dependency and improve comments

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     ss.dependency 'FMDB/standard'
   end
 
-  # use a custom built version of sqlite3
+  # build the latest stable version of sqlite3
   s.subspec 'standalone' do |ss|
     ss.default_subspec = 'default'
     ss.dependency 'FMDB/common'
@@ -36,10 +36,10 @@ Pod::Spec.new do |s|
       sss.dependency 'sqlite3'
     end
 
-    # add FTS, custom FTS tokenizer source files, and unicode61 tokenizer support
+    # build with FTS support and custom FTS tokenizer source files
     ss.subspec 'FTS' do |sss|
       sss.source_files = 'src/extra/fts3/*.{h,m}'
-      sss.dependency 'sqlite3/unicode61'
+      sss.dependency 'sqlite3/fts'
     end
   end
 


### PR DESCRIPTION
The `unicode61` tokenizer is now enabled by default and the `sqlite3/unicode61` subspec is deprecated.
`FMDB/standalone` should depend on `sqlite3/fts` instead.

I also updated the comment to make it clearer that the most recent stable version of
SQLite is built and used if the standalone subspec is selected, not a custom prebuilt
version.

I am the [sqlite3 podspec](https://github.com/clemensg/sqlite3pod) maintainer and am trying to keep the sqlite3 pod as close
to the [official stable release schedule](https://www.sqlite.org/news.html) as possible. Delays should be a few days max.

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>