### PR TITLE
Swift framework carthage

### DIFF
--- a/FMDB-FW-IOS/FMDB-FW-IOS.h
+++ b/FMDB-FW-IOS/FMDB-FW-IOS.h
@@ -1,0 +1,27 @@
+//
+//  FMDB-FW-IOS.h
+//  FMDB-FW-IOS
+//
+//  Created by Michael Gray on 8/31/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for FMDB-FW-IOS.
+FOUNDATION_EXPORT double FMDB_FW_IOSVersionNumber;
+
+//! Project version string for FMDB-FW-IOS.
+FOUNDATION_EXPORT const unsigned char FMDB_FW_IOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FMDB_FW_IOS/PublicHeader.h>
+
+
+
+#import "FMDatabase.h"
+#import "FMResultSet.h"
+#import "FMDatabaseAdditions.h"
+#import "FMDatabaseQueue.h"
+#import "FMDatabase+InMemoryOnDiskIO.h"
+#import "FMDatabase+FTS3.h"
+#import "FMTokenizers.h"

--- a/FMDB-FW-IOS/FMDB.h
+++ b/FMDB-FW-IOS/FMDB.h
@@ -1,0 +1,1 @@
+#import "FMDB-FW-IOS.h"

--- a/FMDB-FW-IOS/Info.plist
+++ b/FMDB-FW-IOS/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/FMDB-FW-IOSTests/FMDB_FW_IOSTests.m
+++ b/FMDB-FW-IOSTests/FMDB_FW_IOSTests.m
@@ -1,0 +1,39 @@
+//
+//  FMDB_FW_IOSTests.m
+//  FMDB-FW-IOSTests
+//
+//  Created by Michael Gray on 8/31/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+
+@interface FMDB_FW_IOSTests : XCTestCase
+
+@end
+
+@implementation FMDB_FW_IOSTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/FMDB-FW-IOSTests/Info.plist
+++ b/FMDB-FW-IOSTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/FMDB-FW-MAC/FMDB-FW-MAC.h
+++ b/FMDB-FW-MAC/FMDB-FW-MAC.h
@@ -1,0 +1,26 @@
+//
+//  FMDB-FW-MAC.h
+//  FMDB-FW-MAC
+//
+//  Created by Michael Gray on 8/31/15.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for FMDB-FW-MAC.
+FOUNDATION_EXPORT double FMDB_FW_MACVersionNumber;
+
+//! Project version string for FMDB-FW-MAC.
+FOUNDATION_EXPORT const unsigned char FMDB_FW_MACVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FMDB_FW_MAC/PublicHeader.h>
+
+
+#import "FMDatabase.h"
+#import "FMResultSet.h"
+#import "FMDatabaseAdditions.h"
+#import "FMDatabaseQueue.h"
+#import "FMDatabase+InMemoryOnDiskIO.h"
+#import "FMDatabase+FTS3.h"
+#import "FMTokenizers.h"

--- a/FMDB-FW-MAC/FMDB.h
+++ b/FMDB-FW-MAC/FMDB.h
@@ -1,0 +1,1 @@
+#import "FMDB-FW-MAC.h"

--- a/FMDB-FW-MAC/Info.plist
+++ b/FMDB-FW-MAC/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/FMDB-FW-MACTests/FMDB_FW_MACTests.m
+++ b/FMDB-FW-MACTests/FMDB_FW_MACTests.m
@@ -1,0 +1,39 @@
+//
+//  FMDB_FW_MACTests.m
+//  FMDB-FW-MACTests
+//
+//  Created by Michael Gray on 8/31/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+
+@interface FMDB_FW_MACTests : XCTestCase
+
+@end
+
+@implementation FMDB_FW_MACTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/FMDB-FW-MACTests/Info.plist
+++ b/FMDB-FW-MACTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -7,6 +7,53 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		091C24D61B94B431002E4E8F /* FMDB-FW-IOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 091C24D51B94B431002E4E8F /* FMDB-FW-IOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C24DD1B94B431002E4E8F /* FMDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 091C24D31B94B431002E4E8F /* FMDB.framework */; settings = {ASSET_TAGS = (); }; };
+		091C24E21B94B431002E4E8F /* FMDB_FW_IOSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 091C24E11B94B431002E4E8F /* FMDB_FW_IOSTests.m */; };
+		091C24F81B94B490002E4E8F /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C24F91B94B490002E4E8F /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */; settings = {ASSET_TAGS = (); }; };
+		091C24FA1B94B490002E4E8F /* FMDatabase+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 83D9D8CE1B6E7DC50083E17F /* FMDatabase+Private.h */; settings = {ASSET_TAGS = (); }; };
+		091C24FB1B94B490002E4E8F /* FMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBF0A13E34D00A6D3E3 /* FMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C24FC1B94B490002E4E8F /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; settings = {ASSET_TAGS = (); }; };
+		091C24FD1B94B490002E4E8F /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CC47A00D148581E9002CCDAB /* FMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C24FE1B94B490002E4E8F /* FMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CC47A00E148581E9002CCDAB /* FMDatabaseQueue.m */; settings = {ASSET_TAGS = (); }; };
+		091C24FF1B94B490002E4E8F /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC50F2CC0DF9183600E4AAAE /* FMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25001B94B490002E4E8F /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */; settings = {ASSET_TAGS = (); }; };
+		091C25011B94B490002E4E8F /* FMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = CC9E4EB713B31188005F9210 /* FMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25021B94B490002E4E8F /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = CC9E4EB813B31188005F9210 /* FMDatabasePool.m */; settings = {ASSET_TAGS = (); }; };
+		091C25031B94B49E002E4E8F /* FMDatabaseVariadic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */; settings = {ASSET_TAGS = (); }; };
+		091C25041B94B4A2002E4E8F /* FMDatabaseAdditionsVariadic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */; settings = {ASSET_TAGS = (); }; };
+		091C25051B94B4AA002E4E8F /* FMDatabase+InMemoryOnDiskIO.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7CE42618F5C04600938264 /* FMDatabase+InMemoryOnDiskIO.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25061B94B4AA002E4E8F /* FMDatabase+InMemoryOnDiskIO.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7CE42718F5C04600938264 /* FMDatabase+InMemoryOnDiskIO.m */; settings = {ASSET_TAGS = (); }; };
+		091C25071B94B4C9002E4E8F /* FMDatabase+FTS3.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA66A2819C0CB1900EFDAC1 /* FMDatabase+FTS3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25081B94B4C9002E4E8F /* FMDatabase+FTS3.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA66A2919C0CB1900EFDAC1 /* FMDatabase+FTS3.m */; settings = {ASSET_TAGS = (); }; };
+		091C25091B94B4C9002E4E8F /* FMTokenizers.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA66A2A19C0CB1900EFDAC1 /* FMTokenizers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C250A1B94B4C9002E4E8F /* FMTokenizers.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA66A2B19C0CB1900EFDAC1 /* FMTokenizers.m */; settings = {ASSET_TAGS = (); }; };
+		091C250C1B94B66D002E4E8F /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 091C250B1B94B66D002E4E8F /* FMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C250E1B94B760002E4E8F /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 091C250D1B94B760002E4E8F /* libsqlite3.tbd */; };
+		091C25171B94B79B002E4E8F /* FMDB-FW-MAC.h in Headers */ = {isa = PBXBuildFile; fileRef = 091C25161B94B79B002E4E8F /* FMDB-FW-MAC.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C251E1B94B79B002E4E8F /* FMDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 091C25141B94B79B002E4E8F /* FMDB.framework */; settings = {ASSET_TAGS = (); }; };
+		091C25231B94B79B002E4E8F /* FMDB_FW_MACTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 091C25221B94B79B002E4E8F /* FMDB_FW_MACTests.m */; };
+		091C252C1B94B7C1002E4E8F /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 091C252B1B94B7C1002E4E8F /* FMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C252D1B94B7EC002E4E8F /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C252E1B94B7EC002E4E8F /* FMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBF0A13E34D00A6D3E3 /* FMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C252F1B94B7EC002E4E8F /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CC47A00D148581E9002CCDAB /* FMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25301B94B7EC002E4E8F /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC50F2CC0DF9183600E4AAAE /* FMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25311B94B7EC002E4E8F /* FMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = CC9E4EB713B31188005F9210 /* FMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25321B94B7EC002E4E8F /* FMDatabase+InMemoryOnDiskIO.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7CE42618F5C04600938264 /* FMDatabase+InMemoryOnDiskIO.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25331B94B7EC002E4E8F /* FMDatabase+FTS3.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA66A2819C0CB1900EFDAC1 /* FMDatabase+FTS3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25341B94B7EC002E4E8F /* FMTokenizers.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA66A2A19C0CB1900EFDAC1 /* FMTokenizers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		091C25351B94B7F9002E4E8F /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */; settings = {ASSET_TAGS = (); }; };
+		091C25361B94B7F9002E4E8F /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; settings = {ASSET_TAGS = (); }; };
+		091C25371B94B7F9002E4E8F /* FMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CC47A00E148581E9002CCDAB /* FMDatabaseQueue.m */; settings = {ASSET_TAGS = (); }; };
+		091C25381B94B7F9002E4E8F /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */; settings = {ASSET_TAGS = (); }; };
+		091C25391B94B7F9002E4E8F /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = CC9E4EB813B31188005F9210 /* FMDatabasePool.m */; settings = {ASSET_TAGS = (); }; };
+		091C253A1B94B7F9002E4E8F /* FMDatabaseVariadic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */; settings = {ASSET_TAGS = (); }; };
+		091C253B1B94B7F9002E4E8F /* FMDatabaseAdditionsVariadic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */; settings = {ASSET_TAGS = (); }; };
+		091C253C1B94B7F9002E4E8F /* FMDatabase+InMemoryOnDiskIO.m in Sources */ = {isa = PBXBuildFile; fileRef = CC7CE42718F5C04600938264 /* FMDatabase+InMemoryOnDiskIO.m */; settings = {ASSET_TAGS = (); }; };
+		091C253D1B94B7F9002E4E8F /* FMDatabase+FTS3.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA66A2919C0CB1900EFDAC1 /* FMDatabase+FTS3.m */; settings = {ASSET_TAGS = (); }; };
+		091C253E1B94B7F9002E4E8F /* FMTokenizers.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA66A2B19C0CB1900EFDAC1 /* FMTokenizers.m */; settings = {ASSET_TAGS = (); }; };
+		091C25401B94B851002E4E8F /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 091C253F1B94B851002E4E8F /* libsqlite3.tbd */; };
 		3354379C19E71096005661F3 /* FMResultSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3354379B19E71096005661F3 /* FMResultSetTests.m */; };
 		621721B21892BFE30006691F /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */; };
 		621721B31892BFE30006691F /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; };
@@ -57,6 +104,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		091C24DE1B94B431002E4E8F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 091C24D21B94B431002E4E8F;
+			remoteInfo = "FMDB-FW-IOS";
+		};
+		091C251F1B94B79B002E4E8F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 091C25131B94B79B002E4E8F;
+			remoteInfo = "FMDB-FW-MAC";
+		};
 		BF5D042318416BB2008C5AA9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
@@ -90,6 +151,22 @@
 
 /* Begin PBXFileReference section */
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		091C24D31B94B431002E4E8F /* FMDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FMDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		091C24D51B94B431002E4E8F /* FMDB-FW-IOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FMDB-FW-IOS.h"; sourceTree = "<group>"; };
+		091C24D71B94B431002E4E8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		091C24DC1B94B431002E4E8F /* FMDB-FW-IOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FMDB-FW-IOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		091C24E11B94B431002E4E8F /* FMDB_FW_IOSTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FMDB_FW_IOSTests.m; sourceTree = "<group>"; };
+		091C24E31B94B431002E4E8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		091C250B1B94B66D002E4E8F /* FMDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FMDB.h; sourceTree = "<group>"; };
+		091C250D1B94B760002E4E8F /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		091C25141B94B79B002E4E8F /* FMDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FMDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		091C25161B94B79B002E4E8F /* FMDB-FW-MAC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FMDB-FW-MAC.h"; sourceTree = "<group>"; };
+		091C25181B94B79B002E4E8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		091C251D1B94B79B002E4E8F /* FMDB-FW-MACTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FMDB-FW-MACTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		091C25221B94B79B002E4E8F /* FMDB_FW_MACTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FMDB_FW_MACTests.m; sourceTree = "<group>"; };
+		091C25241B94B79B002E4E8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		091C252B1B94B7C1002E4E8F /* FMDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FMDB.h; sourceTree = "<group>"; };
+		091C253F1B94B851002E4E8F /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		32A70AAB03705E1F00C91783 /* fmdb_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fmdb_Prefix.pch; path = src/sample/fmdb_Prefix.pch; sourceTree = SOURCE_ROOT; };
 		3354379B19E71096005661F3 /* FMResultSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMResultSetTests.m; sourceTree = "<group>"; };
 		6290CBB5188FE836009790F8 /* libFMDB-IOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libFMDB-IOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -144,6 +221,38 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		091C24CF1B94B431002E4E8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C250E1B94B760002E4E8F /* libsqlite3.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C24D91B94B431002E4E8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C24DD1B94B431002E4E8F /* FMDB.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C25101B94B79B002E4E8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C25401B94B851002E4E8F /* libsqlite3.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C251A1B94B79B002E4E8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C251E1B94B79B002E4E8F /* FMDB.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6290CBB2188FE836009790F8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -195,6 +304,10 @@
 				C6859EA2029092E104C91782 /* Documentation */,
 				08FB779DFE84155DC02AAC07 /* External Frameworks and Libraries */,
 				BF5D041A18416BB2008C5AA9 /* Tests */,
+				091C24D41B94B431002E4E8F /* FMDB-FW-IOS */,
+				091C24E01B94B431002E4E8F /* FMDB-FW-IOSTests */,
+				091C25151B94B79B002E4E8F /* FMDB-FW-MAC */,
+				091C25211B94B79B002E4E8F /* FMDB-FW-MACTests */,
 				BF5D041718416BB2008C5AA9 /* Frameworks */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
 				EE42910C12B42FFA0088BD94 /* libsqlite3.dylib */,
@@ -222,6 +335,44 @@
 			name = "External Frameworks and Libraries";
 			sourceTree = "<group>";
 		};
+		091C24D41B94B431002E4E8F /* FMDB-FW-IOS */ = {
+			isa = PBXGroup;
+			children = (
+				091C250B1B94B66D002E4E8F /* FMDB.h */,
+				091C24D51B94B431002E4E8F /* FMDB-FW-IOS.h */,
+				091C24D71B94B431002E4E8F /* Info.plist */,
+			);
+			path = "FMDB-FW-IOS";
+			sourceTree = "<group>";
+		};
+		091C24E01B94B431002E4E8F /* FMDB-FW-IOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				091C24E11B94B431002E4E8F /* FMDB_FW_IOSTests.m */,
+				091C24E31B94B431002E4E8F /* Info.plist */,
+			);
+			path = "FMDB-FW-IOSTests";
+			sourceTree = "<group>";
+		};
+		091C25151B94B79B002E4E8F /* FMDB-FW-MAC */ = {
+			isa = PBXGroup;
+			children = (
+				091C252B1B94B7C1002E4E8F /* FMDB.h */,
+				091C25161B94B79B002E4E8F /* FMDB-FW-MAC.h */,
+				091C25181B94B79B002E4E8F /* Info.plist */,
+			);
+			path = "FMDB-FW-MAC";
+			sourceTree = "<group>";
+		};
+		091C25211B94B79B002E4E8F /* FMDB-FW-MACTests */ = {
+			isa = PBXGroup;
+			children = (
+				091C25221B94B79B002E4E8F /* FMDB_FW_MACTests.m */,
+				091C25241B94B79B002E4E8F /* Info.plist */,
+			);
+			path = "FMDB-FW-MACTests";
+			sourceTree = "<group>";
+		};
 		1AB674ADFE9D54B511CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -229,6 +380,10 @@
 				EE4290EF12B42F870088BD94 /* libFMDB.a */,
 				BF5D041618416BB2008C5AA9 /* Tests.xctest */,
 				6290CBB5188FE836009790F8 /* libFMDB-IOS.a */,
+				091C24D31B94B431002E4E8F /* FMDB.framework */,
+				091C24DC1B94B431002E4E8F /* FMDB-FW-IOSTests.xctest */,
+				091C25141B94B79B002E4E8F /* FMDB.framework */,
+				091C251D1B94B79B002E4E8F /* FMDB-FW-MACTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -294,6 +449,8 @@
 		BF5D041718416BB2008C5AA9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				091C253F1B94B851002E4E8F /* libsqlite3.tbd */,
+				091C250D1B94B760002E4E8F /* libsqlite3.tbd */,
 				BF5D041818416BB2008C5AA9 /* XCTest.framework */,
 				6290CBB6188FE836009790F8 /* Foundation.framework */,
 				6290CBC6188FE837009790F8 /* UIKit.framework */,
@@ -349,6 +506,41 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		091C24D01B94B431002E4E8F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C25011B94B490002E4E8F /* FMDatabasePool.h in Headers */,
+				091C24FA1B94B490002E4E8F /* FMDatabase+Private.h in Headers */,
+				091C25051B94B4AA002E4E8F /* FMDatabase+InMemoryOnDiskIO.h in Headers */,
+				091C24D61B94B431002E4E8F /* FMDB-FW-IOS.h in Headers */,
+				091C25071B94B4C9002E4E8F /* FMDatabase+FTS3.h in Headers */,
+				091C24FF1B94B490002E4E8F /* FMDatabaseAdditions.h in Headers */,
+				091C250C1B94B66D002E4E8F /* FMDB.h in Headers */,
+				091C24FD1B94B490002E4E8F /* FMDatabaseQueue.h in Headers */,
+				091C24F81B94B490002E4E8F /* FMDatabase.h in Headers */,
+				091C25091B94B4C9002E4E8F /* FMTokenizers.h in Headers */,
+				091C24FB1B94B490002E4E8F /* FMResultSet.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C25111B94B79B002E4E8F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C252F1B94B7EC002E4E8F /* FMDatabaseQueue.h in Headers */,
+				091C25171B94B79B002E4E8F /* FMDB-FW-MAC.h in Headers */,
+				091C25301B94B7EC002E4E8F /* FMDatabaseAdditions.h in Headers */,
+				091C25331B94B7EC002E4E8F /* FMDatabase+FTS3.h in Headers */,
+				091C25311B94B7EC002E4E8F /* FMDatabasePool.h in Headers */,
+				091C252E1B94B7EC002E4E8F /* FMResultSet.h in Headers */,
+				091C252C1B94B7C1002E4E8F /* FMDB.h in Headers */,
+				091C25321B94B7EC002E4E8F /* FMDatabase+InMemoryOnDiskIO.h in Headers */,
+				091C252D1B94B7EC002E4E8F /* FMDatabase.h in Headers */,
+				091C25341B94B7EC002E4E8F /* FMTokenizers.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EE4290EB12B42F870088BD94 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -366,6 +558,78 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		091C24D21B94B431002E4E8F /* FMDB-FW-IOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 091C24E41B94B431002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-IOS" */;
+			buildPhases = (
+				091C24CE1B94B431002E4E8F /* Sources */,
+				091C24CF1B94B431002E4E8F /* Frameworks */,
+				091C24D01B94B431002E4E8F /* Headers */,
+				091C24D11B94B431002E4E8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FMDB-FW-IOS";
+			productName = "FMDB-FW-IOS";
+			productReference = 091C24D31B94B431002E4E8F /* FMDB.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		091C24DB1B94B431002E4E8F /* FMDB-FW-IOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 091C24E71B94B431002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-IOSTests" */;
+			buildPhases = (
+				091C24D81B94B431002E4E8F /* Sources */,
+				091C24D91B94B431002E4E8F /* Frameworks */,
+				091C24DA1B94B431002E4E8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				091C24DF1B94B431002E4E8F /* PBXTargetDependency */,
+			);
+			name = "FMDB-FW-IOSTests";
+			productName = "FMDB-FW-IOSTests";
+			productReference = 091C24DC1B94B431002E4E8F /* FMDB-FW-IOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		091C25131B94B79B002E4E8F /* FMDB-FW-MAC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 091C25251B94B79B002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-MAC" */;
+			buildPhases = (
+				091C250F1B94B79B002E4E8F /* Sources */,
+				091C25101B94B79B002E4E8F /* Frameworks */,
+				091C25111B94B79B002E4E8F /* Headers */,
+				091C25121B94B79B002E4E8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FMDB-FW-MAC";
+			productName = "FMDB-FW-MAC";
+			productReference = 091C25141B94B79B002E4E8F /* FMDB.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		091C251C1B94B79B002E4E8F /* FMDB-FW-MACTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 091C25281B94B79B002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-MACTests" */;
+			buildPhases = (
+				091C25191B94B79B002E4E8F /* Sources */,
+				091C251A1B94B79B002E4E8F /* Frameworks */,
+				091C251B1B94B79B002E4E8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				091C25201B94B79B002E4E8F /* PBXTargetDependency */,
+			);
+			name = "FMDB-FW-MACTests";
+			productName = "FMDB-FW-MACTests";
+			productReference = 091C251D1B94B79B002E4E8F /* FMDB-FW-MACTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		6290CBB4188FE836009790F8 /* FMDB-IOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6290CBD7188FE837009790F8 /* Build configuration list for PBXNativeTarget "FMDB-IOS" */;
@@ -442,8 +706,22 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				TargetAttributes = {
+					091C24D21B94B431002E4E8F = {
+						CreatedOnToolsVersion = 7.0;
+					};
+					091C24DB1B94B431002E4E8F = {
+						CreatedOnToolsVersion = 7.0;
+					};
+					091C25131B94B79B002E4E8F = {
+						CreatedOnToolsVersion = 7.0;
+					};
+					091C251C1B94B79B002E4E8F = {
+						CreatedOnToolsVersion = 7.0;
+					};
 					BF5D041518416BB2008C5AA9 = {
 						TestTargetID = EE4290EE12B42F870088BD94;
 					};
@@ -468,11 +746,43 @@
 				EE4290EE12B42F870088BD94 /* FMDB */,
 				BF5D041518416BB2008C5AA9 /* Tests */,
 				6290CBB4188FE836009790F8 /* FMDB-IOS */,
+				091C24D21B94B431002E4E8F /* FMDB-FW-IOS */,
+				091C24DB1B94B431002E4E8F /* FMDB-FW-IOSTests */,
+				091C25131B94B79B002E4E8F /* FMDB-FW-MAC */,
+				091C251C1B94B79B002E4E8F /* FMDB-FW-MACTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		091C24D11B94B431002E4E8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C24DA1B94B431002E4E8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C25121B94B79B002E4E8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C251B1B94B79B002E4E8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF5D041418416BB2008C5AA9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -484,6 +794,56 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		091C24CE1B94B431002E4E8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C24FC1B94B490002E4E8F /* FMResultSet.m in Sources */,
+				091C25041B94B4A2002E4E8F /* FMDatabaseAdditionsVariadic.swift in Sources */,
+				091C24F91B94B490002E4E8F /* FMDatabase.m in Sources */,
+				091C25061B94B4AA002E4E8F /* FMDatabase+InMemoryOnDiskIO.m in Sources */,
+				091C250A1B94B4C9002E4E8F /* FMTokenizers.m in Sources */,
+				091C25031B94B49E002E4E8F /* FMDatabaseVariadic.swift in Sources */,
+				091C25021B94B490002E4E8F /* FMDatabasePool.m in Sources */,
+				091C25081B94B4C9002E4E8F /* FMDatabase+FTS3.m in Sources */,
+				091C24FE1B94B490002E4E8F /* FMDatabaseQueue.m in Sources */,
+				091C25001B94B490002E4E8F /* FMDatabaseAdditions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C24D81B94B431002E4E8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C24E21B94B431002E4E8F /* FMDB_FW_IOSTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C250F1B94B79B002E4E8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C25361B94B7F9002E4E8F /* FMResultSet.m in Sources */,
+				091C253B1B94B7F9002E4E8F /* FMDatabaseAdditionsVariadic.swift in Sources */,
+				091C25351B94B7F9002E4E8F /* FMDatabase.m in Sources */,
+				091C253C1B94B7F9002E4E8F /* FMDatabase+InMemoryOnDiskIO.m in Sources */,
+				091C253E1B94B7F9002E4E8F /* FMTokenizers.m in Sources */,
+				091C253A1B94B7F9002E4E8F /* FMDatabaseVariadic.swift in Sources */,
+				091C25391B94B7F9002E4E8F /* FMDatabasePool.m in Sources */,
+				091C253D1B94B7F9002E4E8F /* FMDatabase+FTS3.m in Sources */,
+				091C25371B94B7F9002E4E8F /* FMDatabaseQueue.m in Sources */,
+				091C25381B94B7F9002E4E8F /* FMDatabaseAdditions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		091C25191B94B79B002E4E8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				091C25231B94B79B002E4E8F /* FMDB_FW_MACTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6290CBB1188FE836009790F8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -545,6 +905,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		091C24DF1B94B431002E4E8F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 091C24D21B94B431002E4E8F /* FMDB-FW-IOS */;
+			targetProxy = 091C24DE1B94B431002E4E8F /* PBXContainerItemProxy */;
+		};
+		091C25201B94B79B002E4E8F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 091C25131B94B79B002E4E8F /* FMDB-FW-MAC */;
+			targetProxy = 091C251F1B94B79B002E4E8F /* PBXContainerItemProxy */;
+		};
 		BF5D042418416BB2008C5AA9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = EE4290EE12B42F870088BD94 /* FMDB */;
@@ -564,6 +934,300 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		091C24E51B94B431002E4E8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-IOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-IOS";
+				PRODUCT_NAME = FMDB;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		091C24E61B94B431002E4E8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-IOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-IOS";
+				PRODUCT_NAME = FMDB;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		091C24E81B94B431002E4E8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-IOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-IOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		091C24E91B94B431002E4E8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-IOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-IOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		091C25261B94B79B002E4E8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-MAC/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-MAC";
+				PRODUCT_NAME = FMDB;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		091C25271B94B79B002E4E8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-MAC/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-MAC";
+				PRODUCT_NAME = FMDB;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		091C25291B94B79B002E4E8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-MACTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-MACTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		091C252A1B94B79B002E4E8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "FMDB-FW-MACTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-MACTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		1DEB927508733DD40010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -811,6 +1475,42 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		091C24E41B94B431002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-IOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				091C24E51B94B431002E4E8F /* Debug */,
+				091C24E61B94B431002E4E8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		091C24E71B94B431002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-IOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				091C24E81B94B431002E4E8F /* Debug */,
+				091C24E91B94B431002E4E8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		091C25251B94B79B002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-MAC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				091C25261B94B79B002E4E8F /* Debug */,
+				091C25271B94B79B002E4E8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		091C25281B94B79B002E4E8F /* Build configuration list for PBXNativeTarget "FMDB-FW-MACTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				091C25291B94B79B002E4E8F /* Debug */,
+				091C252A1B94B79B002E4E8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "fmdb" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -965,7 +965,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "FMDB-FW-IOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-IOS";
@@ -1004,7 +1004,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "FMDB-FW-IOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.futurekit.org.FMDB-FW-IOS";

--- a/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB-FW-IOS.xcscheme
+++ b/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB-FW-IOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "091C24D21B94B431002E4E8F"
+               BuildableName = "FMDB.framework"
+               BlueprintName = "FMDB-FW-IOS"
+               ReferencedContainer = "container:fmdb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "091C24DB1B94B431002E4E8F"
+               BuildableName = "FMDB-FW-IOSTests.xctest"
+               BlueprintName = "FMDB-FW-IOSTests"
+               ReferencedContainer = "container:fmdb.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "091C24D21B94B431002E4E8F"
+            BuildableName = "FMDB.framework"
+            BlueprintName = "FMDB-FW-IOS"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "091C24D21B94B431002E4E8F"
+            BuildableName = "FMDB.framework"
+            BlueprintName = "FMDB-FW-IOS"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "091C24D21B94B431002E4E8F"
+            BuildableName = "FMDB.framework"
+            BlueprintName = "FMDB-FW-IOS"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB-FW-MAC.xcscheme
+++ b/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB-FW-MAC.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "091C25131B94B79B002E4E8F"
+               BuildableName = "FMDB.framework"
+               BlueprintName = "FMDB-FW-MAC"
+               ReferencedContainer = "container:fmdb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "091C251C1B94B79B002E4E8F"
+               BuildableName = "FMDB-FW-MACTests.xctest"
+               BlueprintName = "FMDB-FW-MACTests"
+               ReferencedContainer = "container:fmdb.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "091C25131B94B79B002E4E8F"
+            BuildableName = "FMDB.framework"
+            BlueprintName = "FMDB-FW-MAC"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "091C25131B94B79B002E4E8F"
+            BuildableName = "FMDB.framework"
+            BlueprintName = "FMDB-FW-MAC"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "091C25131B94B79B002E4E8F"
+            BuildableName = "FMDB.framework"
+            BlueprintName = "FMDB-FW-MAC"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
+++ b/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
@@ -1,4 +1,5 @@
 #import "FMDatabase+InMemoryOnDiskIO.h"
+#import "FMDatabase+Private.h"
 
 // http://www.sqlite.org/backup.html
 static
@@ -63,13 +64,13 @@ int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
     }
     
     // and only if the database is open
-    if ( self->_db == nil ) 
+    if ( self.db == nil )
     {
         NSLog(@"Invalid database connection." );
         return NO;
     }
     
-    return ( SQLITE_OK == loadOrSaveDb( self->_db, [filePath fileSystemRepresentation], false ) );
+    return ( SQLITE_OK == loadOrSaveDb( self.db, [filePath fileSystemRepresentation], false ) );
 
 }
 
@@ -83,14 +84,14 @@ int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
     }
     
     // and only if the database is open
-    if ( self->_db == nil ) 
+    if ( self.db == nil )
     {
         NSLog(@"Invalid database connection." );
         return NO;
     }
     
     // save the in-memory representation    
-    return ( SQLITE_OK == loadOrSaveDb( self->_db, [filePath fileSystemRepresentation], true ) );
+    return ( SQLITE_OK == loadOrSaveDb( self.db, [filePath fileSystemRepresentation], true ) );
 }
 
 @end

--- a/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift
@@ -9,11 +9,11 @@ extension FMDatabase {
     
     /// Private generic function used for the variadic renditions of the FMDatabaseAdditions methods
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The NSArray of the arguments to be bound to the ? placeholders in the SQL.
-    /// :param: completionHandler The closure to be used to call the appropriate FMDatabase method to return the desired value.
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The NSArray of the arguments to be bound to the ? placeholders in the SQL.
+    /// - parameter completionHandler: The closure to be used to call the appropriate FMDatabase method to return the desired value.
     ///
-    /// :returns: This returns the T value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns the T value if value is found. Returns nil if column is NULL or upon error.
     
     private func valueForQuery<T>(sql: String, values: [AnyObject]?, completionHandler:(FMResultSet)->(T!)) -> T! {
         var result: T!
@@ -34,10 +34,10 @@ extension FMDatabase {
     /// This is a rendition of stringForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns string value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns string value if value is found. Returns nil if column is NULL or upon error.
     
     func stringForQuery(sql: String, _ values: AnyObject...) -> String! {
         return valueForQuery(sql, values: values) { $0.stringForColumnIndex(0) }
@@ -46,10 +46,10 @@ extension FMDatabase {
     /// This is a rendition of intForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns integer value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns integer value if value is found. Returns nil if column is NULL or upon error.
     
     func intForQuery(sql: String, _ values: AnyObject...) -> Int32! {
         return valueForQuery(sql, values: values) { $0.intForColumnIndex(0) }
@@ -58,10 +58,10 @@ extension FMDatabase {
     /// This is a rendition of longForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns long value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns long value if value is found. Returns nil if column is NULL or upon error.
     
     func longForQuery(sql: String, _ values: AnyObject...) -> Int! {
         return valueForQuery(sql, values: values) { $0.longForColumnIndex(0) }
@@ -70,10 +70,10 @@ extension FMDatabase {
     /// This is a rendition of boolForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns Bool value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns Bool value if value is found. Returns nil if column is NULL or upon error.
     
     func boolForQuery(sql: String, _ values: AnyObject...) -> Bool! {
         return valueForQuery(sql, values: values) { $0.boolForColumnIndex(0) }
@@ -82,10 +82,10 @@ extension FMDatabase {
     /// This is a rendition of doubleForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns Double value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns Double value if value is found. Returns nil if column is NULL or upon error.
     
     func doubleForQuery(sql: String, _ values: AnyObject...) -> Double! {
         return valueForQuery(sql, values: values) { $0.doubleForColumnIndex(0) }
@@ -94,10 +94,10 @@ extension FMDatabase {
     /// This is a rendition of dateForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns NSDate value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns NSDate value if value is found. Returns nil if column is NULL or upon error.
     
     func dateForQuery(sql: String, _ values: AnyObject...) -> NSDate! {
         return valueForQuery(sql, values: values) { $0.dateForColumnIndex(0) }
@@ -106,10 +106,10 @@ extension FMDatabase {
     /// This is a rendition of dataForQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns NSData value if value is found. Returns nil if column is NULL or upon error.
+    /// - returns: This returns NSData value if value is found. Returns nil if column is NULL or upon error.
     
     func dataForQuery(sql: String, _ values: AnyObject...) -> NSData! {
         return valueForQuery(sql, values: values) { $0.dataForColumnIndex(0) }

--- a/src/extra/Swift extensions/FMDatabaseVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseVariadic.swift
@@ -13,10 +13,10 @@ extension FMDatabase {
     /// This is a rendition of executeQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns FMResultSet if successful. Returns nil upon error.
+    /// - returns: This returns FMResultSet if successful. Returns nil upon error.
     
     func executeQuery(sql:String, _ values: AnyObject...) -> FMResultSet? {
         return executeQuery(sql, withArgumentsInArray: values as [AnyObject]);
@@ -25,10 +25,10 @@ extension FMDatabase {
     /// This is a rendition of executeUpdate that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
-    /// :param: sql The SQL statement to be used.
-    /// :param: values The values to be bound to the ? placeholders
+    /// - parameter sql: The SQL statement to be used.
+    /// - parameter values: The values to be bound to the ? placeholders
     ///
-    /// :returns: This returns true if successful. Returns false upon error.
+    /// - returns: This returns true if successful. Returns false upon error.
     
     func executeUpdate(sql:String, _ values: AnyObject...) -> Bool {
         return executeUpdate(sql, withArgumentsInArray: values as [AnyObject]);


### PR DESCRIPTION
This PR adds OS X 10.10+ & iOS 8.0+ Framework targets that are Carthage friendly, swift 2.0 friendly, and fix the 'sqlite.h" import issues. 

if you want to test, just add:
github "mishagray/fmdb" "swiftFrameworkCarthage"

to your local Cartfile.  Make sure to add 'import FMDB' to any existing swift code.

I've tested this in XCode7b6.  But it should work as-is for Xcode 6.4 (there is no swift 2.0 specific code here!)
