### PR TITLE
Allow selecting NSDate epoch

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -90,6 +90,8 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
     NSMutableSet        *_openFunctions;
 
     NSDateFormatter     *_dateFormat;
+    SEL                 _dateInitializer;
+    SEL                 _dateExtractor;
 }
 
 ///-----------------
@@ -1023,6 +1025,46 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  */
 
 - (NSString *)stringFromDate:(NSDate *)date;
+
+///---------------------
+/// @name Date epoch
+///---------------------
+
+/** Sets the NSDate epoch to the Unix/C standard January 1, 1970
+ */
+
+-(void) setDateEpoch1970;
+
+/** Sets the NSDate epoch to the Cocoa standard reference date.
+ */
+
+-(void) setDateEpochReferenceDate;
+
+/** Convert the supplied double to NSDate, using the current date epoch.
+ 
+ @param d `double` to convert to `NSDate`.
+ 
+ @return The `NSDate` object.
+ 
+ @see setDateEpoch1970
+ @see setDateEpochReference
+ @see doubleFromDate:
+ */
+
+- (NSDate *)dateFromDouble:(double)d;
+
+/** Convert the supplied NSDate to double, using the current date epoch.
+ 
+ @param date `NSDate` of date to convert to `double`.
+ 
+ @return The `double` value of the date.
+ 
+ @see setDateEpoch1970
+ @see setDateEpochReference
+ @see dateFromDouble:
+ */
+
+- (double)doubleFromDate:(NSDate *)date;
 
 @end
 

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -2,6 +2,12 @@
 #import "unistd.h"
 #import <objc/runtime.h>
 
+
+// Date initializer & extractor method binders
+typedef NSDate *(*DateInitializerMethod)(id inst, SEL cmd);
+typedef double(*DateExtractorMethod)(id inst, SEL cmd);
+
+
 @interface FMDatabase ()
 
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;
@@ -39,6 +45,7 @@
         _logsErrors                 = YES;
         _crashOnErrors              = NO;
         _maxBusyRetryTimeInterval   = 2;
+        [self setDateEpoch1970];
     }
     
     return self;
@@ -424,6 +431,26 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
     return [_dateFormat stringFromDate:date];
 }
 
+- (void) setDateEpoch1970 {
+    _dateInitializer = @selector(dateWithTimeIntervalSince1970:);
+    _dateExtractor = @selector(timeIntervalSince1970);
+}
+
+- (void) setDateEpochReferenceDate {
+    _dateInitializer = @selector(dateWithTimeIntervalSinceReferenceDate:);
+    _dateExtractor = @selector(timeIntervalSinceReferenceDate);
+}
+
+- (NSDate *)dateFromDouble:(double)d {
+    DateInitializerMethod initializer = (DateInitializerMethod)[NSDate.class methodForSelector:_dateInitializer];
+    return initializer(NSDate.class, _dateInitializer);
+}
+
+- (double)doubleFromDate:(NSDate *)date {
+    DateExtractorMethod extractor = (DateExtractorMethod)[date methodForSelector:_dateExtractor];
+    return extractor(date, _dateExtractor);
+}
+
 #pragma mark State of database
 
 - (BOOL)goodConnection {
@@ -553,7 +580,7 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
         if (self.hasDateFormatter)
             sqlite3_bind_text(pStmt, idx, [[self stringFromDate:obj] UTF8String], -1, SQLITE_STATIC);
         else
-            sqlite3_bind_double(pStmt, idx, [obj timeIntervalSince1970]);
+            sqlite3_bind_double(pStmt, idx, [self doubleFromDate:obj]);
     }
     else if ([obj isKindOfClass:[NSNumber class]]) {
         

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -300,7 +300,7 @@
         return nil;
     }
     
-    return [_parentDB hasDateFormatter] ? [_parentDB dateFromString:[self stringForColumnIndex:columnIdx]] : [NSDate dateWithTimeIntervalSince1970:[self doubleForColumnIndex:columnIdx]];
+    return [_parentDB hasDateFormatter] ? [_parentDB dateFromString:[self stringForColumnIndex:columnIdx]] : [_parentDB dateFromDouble:[self doubleForColumnIndex:columnIdx]];
 }
 
 


### PR DESCRIPTION
You can select between the 1970 and reference epoch at runtime .  Works much like the date formatter setting including adding FMDatabase.doubleFromDate & FMDatabase.dateFromDouble methods.
