### PR TITLE
Added ignored diagnostic for `-Wauto-import` & `-Wobjc-interface-ivars`

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -1,7 +1,12 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wauto-import"
+
 #import <Foundation/Foundation.h>
 #import "sqlite3.h"
 #import "FMResultSet.h"
 #import "FMDatabasePool.h"
+
+#pragma clang diagnostic pop
 
 
 #if ! __has_feature(objc_arc)

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1,6 +1,11 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wauto-import"
+
 #import "FMDatabase.h"
 #import "unistd.h"
 #import <objc/runtime.h>
+
+#pragma clang diagnostic pop
 
 @interface FMDatabase ()
 

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -6,7 +6,13 @@
 //  Copyright 2011 Flying Meat Inc. All rights reserved.
 //
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wauto-import"
+
 #import <Foundation/Foundation.h>
+
+#pragma clang diagnostic pop
+
 #import "sqlite3.h"
 
 @class FMDatabase;
@@ -29,6 +35,9 @@
  in the main.m file.
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-interface-ivars"
+
 @interface FMDatabasePool : NSObject {
     NSString            *_path;
     
@@ -42,6 +51,8 @@
     NSUInteger          _maximumNumberOfDatabasesToCreate;
     int                 _openFlags;
 }
+
+#pragma clang diagnostic pop
 
 /** Database path */
 

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -1,5 +1,10 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wauto-import"
+
 #import <Foundation/Foundation.h>
 #import "sqlite3.h"
+
+#pragma clang diagnostic pop
 
 #ifndef __has_feature      // Optional.
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.
@@ -23,6 +28,9 @@
  - `<FMDatabase>`
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-interface-ivars"
+
 @interface FMResultSet : NSObject {
     FMDatabase          *_parentDB;
     FMStatement         *_statement;
@@ -30,6 +38,8 @@
     NSString            *_query;
     NSMutableDictionary *_columnNameToIndexMap;
 }
+
+#pragma clang diagnostic pop
 
 ///-----------------
 /// @name Properties

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -1,6 +1,11 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wauto-import"
+
 #import "FMResultSet.h"
 #import "FMDatabase.h"
 #import "unistd.h"
+
+#pragma clang diagnostic pop
 
 @interface FMDatabase ()
 - (void)resultSetDidClose:(FMResultSet *)resultSet;


### PR DESCRIPTION
Added `-Wauto-import` ignored for projects that enforce the `@import Foundation;` module syntax.

Added `-Wobjc-interface-ivars` for consistency with `FMDatabase.h`
