### PR TITLE
Added HAVE_USLEEP=1 to fmdb/SQLCipher

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.subspec 'SQLCipher' do |ss|
     ss.dependency 'SQLCipher'
     ss.dependency 'FMDB/common'
-    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC' }
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }
   end
   
 end


### PR DESCRIPTION
I use fmdb/SQLCipher (Xcode7)and got warnings like this when program run:
```
WARNING: Requested sleep of 65 milliseconds, but SQLite returned 1000. Maybe SQLite wasn't built with HAVE_USLEEP=1?
```

I found the warning message in line 237 of FMDatabase.m:
```
 int requestedSleepInMillseconds = arc4random_uniform(50) + 50;
        int actualSleepInMilliseconds =
sqlite3_sleep(requestedSleepInMillseconds);
        if (actualSleepInMilliseconds != requestedSleepInMillseconds) {
            NSLog(@"WARNING: Requested sleep of %i milliseconds, but
SQLite returned %i. Maybe SQLite wasn't built with HAVE_USLEEP=1?",
requestedSleepInMillseconds, actualSleepInMilliseconds);
        }
        return 1;
```
and in line 33239 of sqlite3.m
```
/
static int unixSleep(sqlite3_vfs *NotUsed, int microseconds){
#if OS_VXWORKS
  struct timespec sp;

  sp.tv_sec = microseconds / 1000000;
  sp.tv_nsec = (microseconds % 1000000) * 1000;
  nanosleep(&sp, NULL);
  UNUSED_PARAMETER(NotUsed);
  return microseconds;
#elif defined(HAVE_USLEEP) && HAVE_USLEEP
  usleep(microseconds);
  UNUSED_PARAMETER(NotUsed);
  return microseconds;
#else
  int seconds = (microseconds+999999)/1000000;
  sleep(seconds);
  UNUSED_PARAMETER(NotUsed);
  return seconds*1000000;
#endif
}
```
Currently , there is not an macro of HAVE_USLEEP=1 , and program will go enter the `else` block (not the `elif defined(HAVE_USLEEP) && HAVE_USLEEP` block.

So , add the HAVE_USLEEP=1 .

