### PR TITLE
swift framework compatibility when using FTS 3

### DIFF
--- a/src/extra/fts3/FMDatabase+FTS3.m
+++ b/src/extra/fts3/FMDatabase+FTS3.m
@@ -8,7 +8,7 @@
 
 #import "FMDatabase+FTS3.h"
 #import "fts3_tokenizer.h"
-
+#include "sqlite3.h"
 NSString *const kFTSCommandOptimize = @"optimize";
 NSString *const kFTSCommandRebuild  = @"rebuild";
 NSString *const kFTSCommandIntegrityCheck = @"integrity-check";

--- a/src/extra/fts3/fts3_tokenizer.h
+++ b/src/extra/fts3/fts3_tokenizer.h
@@ -24,7 +24,6 @@
 ** If tokenizers are to be allowed to call sqlite3_*() functions, then
 ** we will need a way to register the API consistently.
 */
-#include "sqlite3.h"
 
 /*
 ** Structures used by the tokenizer interface. When a new tokenizer


### PR DESCRIPTION
I moved the inclusion of the file "sqlite3.h" from src/extra/fts3/fts3_tokenizer.h to src/extra/fts3/FMDatabase+FTS3.m because of a compilation error when using fmdb/fts on pods using frameworks ...

sorry for the branch name ...