### PR TITLE
Bugfix: columnNameForIndex raised an Exception if the index does not exist in FMResultSet

### DIFF
--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -397,7 +397,8 @@
 
 // returns autoreleased NSString containing the name of the column in the result set
 - (NSString*)columnNameForIndex:(int)columnIdx {
-    return [NSString stringWithUTF8String: sqlite3_column_name([_statement statement], columnIdx)];
+    const char* name = (const char*)sqlite3_column_name([_statement statement], columnIdx);
+    return name == NULL ? nil : [NSString stringWithUTF8String: name];
 }
 
 - (void)setParentDB:(FMDatabase *)newDb {


### PR DESCRIPTION
See https://github.com/ccgus/fmdb/issues/429