### PR TITLE
Allow FTS to be compiled as Swift framework

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -26,6 +26,7 @@ Pod::Spec.new do |s|
   s.subspec 'FTS' do |ss|
     ss.source_files = 'src/extra/fts3/*.{h,m}'
     ss.dependency 'FMDB/standard'
+    ss.private_header_files = 'src/extra/fts3/fts3_tokenizer.h'
   end
 
   # use a custom built version of sqlite3
@@ -41,6 +42,7 @@ Pod::Spec.new do |s|
     ss.subspec 'FTS' do |sss|
       sss.source_files = 'src/extra/fts3/*.{h,m}'
       sss.dependency 'sqlite3/unicode61'
+      sss.private_header_files = 'src/extra/fts3/fts3_tokenizer.h'
     end
   end
 


### PR DESCRIPTION
fts3_tokenizer.h only needs to be included privately by
FMDatabase+FTS3.m so we can exclude it from the umbrella header.
cc @newyankeecodeshop 