### PR TITLE
Rework SQLite dependency imports and Podspec structure

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,24 +1,19 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.5'
+  s.version = '2.5.1'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
-  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => 'v2.5' }
+  s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => "#{s.version}" }
   s.requires_arc = true
-
-  s.default_subspec = 'standard'
-
-  s.subspec 'common' do |ss|
-    ss.source_files = 'src/fmdb/FM*.{h,m}'
-    ss.exclude_files = 'src/fmdb.m'
-  end
+  s.default_subspec = 'standard'  
 
   # use the built-in library version of sqlite3
   s.subspec 'standard' do |ss|
     ss.library = 'sqlite3'
-    ss.dependency 'FMDB/common'
+    ss.source_files = 'src/fmdb/FM*.{h,m}'
+    ss.exclude_files = 'src/fmdb.m'
   end
 
   # use the built-in library version of sqlite3 with custom FTS tokenizer source files
@@ -27,26 +22,30 @@ Pod::Spec.new do |s|
     ss.dependency 'FMDB/standard'
   end
 
-  # build the latest stable version of sqlite3
+  # use a custom built version of sqlite3
   s.subspec 'standalone' do |ss|
-    ss.default_subspec = 'default'
-    ss.dependency 'FMDB/common'
+    ss.default_subspec = 'default'    
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE -DHAVE_USLEEP=1' }
     
     ss.subspec 'default' do |sss|
       sss.dependency 'sqlite3'
+      sss.source_files = 'src/fmdb/FM*.{h,m}'
+      sss.exclude_files = 'src/fmdb.m'
     end
 
-    # build with FTS support and custom FTS tokenizer source files
+    # add FTS, custom FTS tokenizer source files, and unicode61 tokenizer support
     ss.subspec 'FTS' do |sss|
       sss.source_files = 'src/extra/fts3/*.{h,m}'
-      sss.dependency 'sqlite3/fts'
+      sss.dependency 'sqlite3/unicode61'
+      sss.dependency 'FMDB/standalone/default'
     end
   end
 
   # use SQLCipher and enable -DSQLITE_HAS_CODEC flag
   s.subspec 'SQLCipher' do |ss|
     ss.dependency 'SQLCipher'
-    ss.dependency 'FMDB/common'
+    ss.source_files = 'src/fmdb/FM*.{h,m}'
+    ss.exclude_files = 'src/fmdb.m'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }
   end
   

--- a/src/extra/fts3/FMDatabase+FTS3.h
+++ b/src/extra/fts3/FMDatabase+FTS3.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Andrew Goodale. All rights reserved.
 //
 
-#import "FMDatabase.h"
+#import <FMDB/FMDatabase.h>
 
 /**
  Names of commands that can be issued against an FTS table.

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
 #import "FMResultSet.h"
 #import "FMDatabasePool.h"
 

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -7,7 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
 
 @class FMDatabase;
 

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -7,7 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
 
 @class FMDatabase;
 

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import "sqlite3.h"
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
 
 #ifndef __has_feature      // Optional.
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.


### PR DESCRIPTION
This PR addresses some build issues I encountered when working with the latest CocoaPods and the Xcode 7.2 beta. The compiler is becoming much stricter about non-modular imports and some things in the project that previously worked began throwing errors. Here is a rundown of the changes:

1. I eliminated the `common` subspec entirely because it failed to build during lint. The issue is that since it did not declare a dependency on either the SQLite standalone or pull in the `sqlite3` library it could not build (symbol errors for SQLite). I simply inlined the `source_files` and `exclude_files` at the appropriate places. This has the added benefit of reducing `pod spec lint` times for the project because there’s one less subspec to be built for all targets (watchOS, tvOS, iOS, OS X).
2. I conditionalized the SQLite imports using a constant set in the podspec (`FMDB_SQLITE_STANDALONE `). Under the Xcode 7.2 compiler `#import “sqlite3.h”` was producing a non-modular import error because its not part of the FMDB module. We now from the system or the standalone dependency framework explicitly.
3. I added a missing dependency between the FTS subspec and the main FMDB sources. There was another non-modular import from trying to import `FMDatabase.h` across modules.