### PR TITLE
Framework and Carthage Support

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -1,16 +1,23 @@
 TODO:
 Zip, nada, zilch.  Got any ideas?
 
-If you would like to contribute some code- awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add a couple of tests for your new code to fmdb.m.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
+If you would like to contribute some code ... awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add the necessary of tests for your new code to tests target.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
+
+2015.12.28
+    Removed `sqlite3.h` from the headers to simplify incorporation of FMDB into a framework. This eliminates the dreaded "non-modular headers" error in frameworks.
+
+    To accomplish this, the few references to SQLite pointers have been changed to return `void` pointers. This means that if you have application code that used SQLite pointers exposed by FMDB, you may have to cast the pointer to the appropriate type when you use it (and `#import <sqlite3.h>` yourself). In general, we would advise against using SQLite pointers unless you absolutely need to.
+
+    Also changed the `FMDatabaseVariadic.swift` to throw errors for Swift 2.
 
 2015.10.29
     Added renditions of `executeUpdate:values:error:` and `executeQuery:values:error:`, which in Swift 2 throw errors.
 
 2015.01.23
-    Added Swift renditions of the variadic methods of FMDatabaseAdditions.
+    Added Swift renditions of the variadic methods of `FMDatabaseAdditions`.
 
 2014.10.19
-Added a 'nextWithError:' to FMResultSet.  Thanks to Roshan Muralidharan for the patch.
+    Added a `nextWithError:` to `FMResultSet`.  Thanks to Roshan Muralidharan for the patch.
 
 2014.09.10
     New classes for exposing SQLite's FTS features.  Thanks to Andrew Goodale for the code.
@@ -18,7 +25,7 @@ Added a 'nextWithError:' to FMResultSet.  Thanks to Roshan Muralidharan for the 
 2014.04.23
     New executeStatements: method, which will take a single UTF-8 string with multiple statements in it.  This is great for batch updates.  There is also a executeStatements:withResultBlock: version which takes a callback block which will be used for any statements which return rows in the bulk statement.  Thanks to Rob Ryan for contributing code for this.
 
-    Deprecated update:withErrorAndBindings: in favor of executeUpdate:withErrorAndBindings:
+    Deprecated `update:withErrorAndBindings:` in favor of `executeUpdate:withErrorAndBindings:` or `executeUpdate:values:error:`.
 
 2014.04.09
     Added back in busy handler code after a brief hiatus (check out the 2013.12.10 notes).  But now doing so with sqlite3_busy_handler instead of while loops in the various execution places.

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.5.2'
+  s.version = '2.6'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,5 @@
-# FMDB v2.5
+# FMDB v2.6
+
 This is an Objective-C wrapper around SQLite: http://sqlite.org/
 
 ## The FMDB Mailing List:

--- a/Tests/FMDatabaseAdditionsTests.m
+++ b/Tests/FMDatabaseAdditionsTests.m
@@ -9,6 +9,12 @@
 #import <XCTest/XCTest.h>
 #import "FMDatabaseAdditions.h"
 
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
+
 @interface FMDatabaseAdditionsTests : FMDBTempDBTests
 
 @end
@@ -101,9 +107,8 @@
     XCTAssertTrue([[self db] userVersion] == 12);
 }
 
+- (void)testApplicationID {
 #if SQLITE_VERSION_NUMBER >= 3007017
-- (void)testApplicationID
-{
     uint32_t appID = NSHFSTypeCodeFromFileType(NSFileTypeForHFSTypeCode('fmdb'));
     
     [self.db setApplicationID:appID];
@@ -117,7 +122,11 @@
     NSString *s = [self.db applicationIDString];
     
     XCTAssertEqualObjects(s, @"acrn");
-}
+#else
+    NSString *errorMessage = NSLocalizedString(@"Application ID functions require SQLite 3.7.17", nil);
+    XCTFail("%@", errorMessage);
+    if (self.db.logsErrors) NSLog(@"%@", errorMessage);
 #endif
+}
 
 @end

--- a/Tests/FMDatabaseQueueTests.m
+++ b/Tests/FMDatabaseQueueTests.m
@@ -9,6 +9,12 @@
 #import <XCTest/XCTest.h>
 #import "FMDatabaseQueue.h"
 
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
+
 @interface FMDatabaseQueueTests : FMDBTempDBTests
 
 @property FMDatabaseQueue *queue;

--- a/Tests/FMDatabaseTests.m
+++ b/Tests/FMDatabaseTests.m
@@ -10,6 +10,13 @@
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"
 
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
+
+
 @interface FMDatabaseTests : FMDBTempDBTests
 
 @end
@@ -804,7 +811,7 @@
     [self.db executeUpdate:@"insert into ftest values ('not h!')"];
     [self.db executeUpdate:@"insert into ftest values ('definitely not h!')"];
     
-    [self.db makeFunctionNamed:@"StringStartsWithH" maximumArguments:1 withBlock:^(sqlite3_context *context, int aargc, sqlite3_value **aargv) {
+    [self.db makeFunctionNamed:@"StringStartsWithH" maximumArguments:1 withBlock:^(void *context, int aargc, void **aargv) {
         if (sqlite3_value_type(aargv[0]) == SQLITE_TEXT) {
             
             @autoreleasepool {
@@ -833,7 +840,7 @@
 }
 
 - (void)testVersionNumber {
-    XCTAssertTrue([FMDatabase FMDBVersion] == 0x0250); // this is going to break everytime we bump it.
+    XCTAssertTrue([FMDatabase FMDBVersion] == 0x0260); // this is going to break everytime we bump it.
 }
 
 - (void)testExecuteStatements

--- a/Tests/FMResultSetTests.m
+++ b/Tests/FMResultSetTests.m
@@ -10,6 +10,12 @@
 #import "FMDatabase.h"
 #import "FMResultSet.h"
 
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
+
 @interface FMResultSetTests : FMDBTempDBTests
 
 @end

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -23,12 +23,36 @@
 		6290CBB7188FE836009790F8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6290CBB6188FE836009790F8 /* Foundation.framework */; };
 		67CB1E3019AD27D000A3CA7F /* FMDatabaseFTS3Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 67CB1E2F19AD27D000A3CA7F /* FMDatabaseFTS3Tests.m */; };
 		8314AF3318CD73D600EC0E25 /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 8314AF3218CD73D600EC0E25 /* FMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F131C326B9400FFC730 /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */; };
+		83C73F141C326B9400FFC730 /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; };
+		83C73F151C326B9400FFC730 /* FMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CC47A00E148581E9002CCDAB /* FMDatabaseQueue.m */; };
+		83C73F161C326B9400FFC730 /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */; };
+		83C73F171C326B9400FFC730 /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = CC9E4EB813B31188005F9210 /* FMDatabasePool.m */; };
+		83C73F181C326BAB00FFC730 /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 8314AF3218CD73D600EC0E25 /* FMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F191C326BAB00FFC730 /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F1A1C326BAB00FFC730 /* FMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBF0A13E34D00A6D3E3 /* FMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F1B1C326BAB00FFC730 /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CC47A00D148581E9002CCDAB /* FMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F1C1C326BAB00FFC730 /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC50F2CC0DF9183600E4AAAE /* FMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F1D1C326BAB00FFC730 /* FMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = CC9E4EB713B31188005F9210 /* FMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F1E1C326BC100FFC730 /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EBB0A13E34D00A6D3E3 /* FMDatabase.m */; };
+		83C73F1F1C326BC100FFC730 /* FMResultSet.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC24EC00A13E34D00A6D3E3 /* FMResultSet.m */; };
+		83C73F201C326BC100FFC730 /* FMDatabaseQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CC47A00E148581E9002CCDAB /* FMDatabaseQueue.m */; };
+		83C73F211C326BC100FFC730 /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */; };
+		83C73F221C326BC100FFC730 /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = CC9E4EB813B31188005F9210 /* FMDatabasePool.m */; };
+		83C73F231C326BD600FFC730 /* FMDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 8314AF3218CD73D600EC0E25 /* FMDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F241C326BD600FFC730 /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBA0A13E34D00A6D3E3 /* FMDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F251C326BD600FFC730 /* FMResultSet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCC24EBF0A13E34D00A6D3E3 /* FMResultSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F261C326BD600FFC730 /* FMDatabaseQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CC47A00D148581E9002CCDAB /* FMDatabaseQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F271C326BD600FFC730 /* FMDatabaseAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC50F2CC0DF9183600E4AAAE /* FMDatabaseAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F281C326BD600FFC730 /* FMDatabasePool.h in Headers */ = {isa = PBXBuildFile; fileRef = CC9E4EB713B31188005F9210 /* FMDatabasePool.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83C73F2A1C326CE800FFC730 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 83C73F291C326CE800FFC730 /* libsqlite3.tbd */; };
+		83C73F2C1C326CF400FFC730 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 83C73F2B1C326CF400FFC730 /* libsqlite3.tbd */; };
+		83C73F2F1C326D2F00FFC730 /* FMDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83C73F0B1C326ADA00FFC730 /* FMDB.framework */; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
 		8DD76F9F0486AA7600D96B5E /* fmdb.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = C6859EA3029092ED04C91782 /* fmdb.1 */; };
 		BF5D041918416BB2008C5AA9 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5D041818416BB2008C5AA9 /* XCTest.framework */; };
 		BF5D041F18416BB2008C5AA9 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF5D041D18416BB2008C5AA9 /* InfoPlist.strings */; };
 		BF5D042118416BB2008C5AA9 /* FMDatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5D042018416BB2008C5AA9 /* FMDatabaseTests.m */; };
-		BF5D04281841702E008C5AA9 /* libFMDB.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EE4290EF12B42F870088BD94 /* libFMDB.a */; };
 		BF940F5C18417D490001E077 /* FMDBTempDBTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF940F5B18417D490001E077 /* FMDBTempDBTests.m */; };
 		BF940F5E18417DEA0001E077 /* FMDatabaseAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF940F5D18417DEA0001E077 /* FMDatabaseAdditionsTests.m */; };
 		BFC152B118417F0D00605DF7 /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */; };
@@ -60,12 +84,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		BF5D042318416BB2008C5AA9 /* PBXContainerItemProxy */ = {
+		83C73F2D1C326D2000FFC730 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = EE4290EE12B42F870088BD94;
-			remoteInfo = FMDB;
+			remoteGlobalIDString = 83C73F0A1C326ADA00FFC730;
+			remoteInfo = "FMDB MacOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -103,6 +127,12 @@
 		831DE6FD175B7C9C001F7317 /* README.markdown */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.markdown; sourceTree = "<group>"; };
 		832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FMDatabaseVariadic.swift; path = "src/extra/Swift extensions/FMDatabaseVariadic.swift"; sourceTree = "<group>"; };
 		8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FMDatabaseAdditionsVariadic.swift; path = "src/extra/Swift extensions/FMDatabaseAdditionsVariadic.swift"; sourceTree = "<group>"; };
+		83C73EFE1C326AB000FFC730 /* FMDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FMDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		83C73F0B1C326ADA00FFC730 /* FMDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FMDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		83C73F291C326CE800FFC730 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		83C73F2B1C326CF400FFC730 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.2.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
+		83C73F301C326D8600FFC730 /* FMDB.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = FMDB.podspec; sourceTree = "<group>"; };
+		83C73F311C326FA600FFC730 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = src/fmdb/Info.plist; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* fmdb */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fmdb; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF5D041618416BB2008C5AA9 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF5D041818416BB2008C5AA9 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -152,6 +182,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		83C73EFA1C326AB000FFC730 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83C73F2C1C326CF400FFC730 /* libsqlite3.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		83C73F071C326ADA00FFC730 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83C73F2A1C326CE800FFC730 /* libsqlite3.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8DD76F9B0486AA7600D96B5E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -166,7 +212,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF5D04281841702E008C5AA9 /* libFMDB.a in Frameworks */,
+				83C73F2F1C326D2F00FFC730 /* FMDB.framework in Frameworks */,
 				BF5D041918416BB2008C5AA9 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -184,12 +230,9 @@
 		08FB7794FE84155DC02AAC07 /* fmdb */ = {
 			isa = PBXGroup;
 			children = (
-				831DE6FD175B7C9C001F7317 /* README.markdown */,
-				CC8C138B0E3135C400FBE1E7 /* LICENSE.txt */,
-				CC8C138A0E3135C400FBE1E7 /* CHANGES_AND_TODO_LIST.txt */,
-				CC8C138C0E3135C400FBE1E7 /* CONTRIBUTORS.txt */,
-				08FB7795FE84155DC02AAC07 /* Source */,
+				83C73F301C326D8600FFC730 /* FMDB.podspec */,
 				C6859EA2029092E104C91782 /* Documentation */,
+				08FB7795FE84155DC02AAC07 /* Source */,
 				08FB779DFE84155DC02AAC07 /* External Frameworks and Libraries */,
 				BF5D041A18416BB2008C5AA9 /* Tests */,
 				BF5D041718416BB2008C5AA9 /* Frameworks */,
@@ -225,6 +268,8 @@
 				EE4290EF12B42F870088BD94 /* libFMDB.a */,
 				BF5D041618416BB2008C5AA9 /* Tests.xctest */,
 				6290CBB5188FE836009790F8 /* libFMDB-IOS.a */,
+				83C73EFE1C326AB000FFC730 /* FMDB.framework */,
+				83C73F0B1C326ADA00FFC730 /* FMDB.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -255,6 +300,7 @@
 				CC50F2CB0DF9183600E4AAAE /* FMDatabaseAdditions.m */,
 				CC9E4EB713B31188005F9210 /* FMDatabasePool.h */,
 				CC9E4EB813B31188005F9210 /* FMDatabasePool.m */,
+				83C73F311C326FA600FFC730 /* Info.plist */,
 			);
 			name = fmdb;
 			sourceTree = "<group>";
@@ -289,6 +335,8 @@
 		BF5D041718416BB2008C5AA9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				83C73F2B1C326CF400FFC730 /* libsqlite3.tbd */,
+				83C73F291C326CE800FFC730 /* libsqlite3.tbd */,
 				BF5D041818416BB2008C5AA9 /* XCTest.framework */,
 				6290CBB6188FE836009790F8 /* Foundation.framework */,
 				6290CBC6188FE837009790F8 /* UIKit.framework */,
@@ -326,6 +374,10 @@
 		C6859EA2029092E104C91782 /* Documentation */ = {
 			isa = PBXGroup;
 			children = (
+				831DE6FD175B7C9C001F7317 /* README.markdown */,
+				CC8C138B0E3135C400FBE1E7 /* LICENSE.txt */,
+				CC8C138A0E3135C400FBE1E7 /* CHANGES_AND_TODO_LIST.txt */,
+				CC8C138C0E3135C400FBE1E7 /* CONTRIBUTORS.txt */,
 				C6859EA3029092ED04C91782 /* fmdb.1 */,
 			);
 			name = Documentation;
@@ -354,6 +406,32 @@
 				40A146051BE6999800E5D35E /* FMDB.h in Headers */,
 				40A146031BE575E400E5D35E /* FMDatabaseAdditions.h in Headers */,
 				40A146021BE575DD00E5D35E /* FMDatabaseQueue.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		83C73EFB1C326AB000FFC730 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83C73F181C326BAB00FFC730 /* FMDB.h in Headers */,
+				83C73F191C326BAB00FFC730 /* FMDatabase.h in Headers */,
+				83C73F1A1C326BAB00FFC730 /* FMResultSet.h in Headers */,
+				83C73F1B1C326BAB00FFC730 /* FMDatabaseQueue.h in Headers */,
+				83C73F1C1C326BAB00FFC730 /* FMDatabaseAdditions.h in Headers */,
+				83C73F1D1C326BAB00FFC730 /* FMDatabasePool.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		83C73F081C326ADA00FFC730 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83C73F231C326BD600FFC730 /* FMDB.h in Headers */,
+				83C73F241C326BD600FFC730 /* FMDatabase.h in Headers */,
+				83C73F251C326BD600FFC730 /* FMResultSet.h in Headers */,
+				83C73F261C326BD600FFC730 /* FMDatabaseQueue.h in Headers */,
+				83C73F271C326BD600FFC730 /* FMDatabaseAdditions.h in Headers */,
+				83C73F281C326BD600FFC730 /* FMDatabasePool.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -391,6 +469,42 @@
 			productReference = 6290CBB5188FE836009790F8 /* libFMDB-IOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		83C73EFD1C326AB000FFC730 /* FMDB iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 83C73F051C326AB000FFC730 /* Build configuration list for PBXNativeTarget "FMDB iOS" */;
+			buildPhases = (
+				83C73EF91C326AB000FFC730 /* Sources */,
+				83C73EFA1C326AB000FFC730 /* Frameworks */,
+				83C73EFB1C326AB000FFC730 /* Headers */,
+				83C73EFC1C326AB000FFC730 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FMDB iOS";
+			productName = "FMDB iOS";
+			productReference = 83C73EFE1C326AB000FFC730 /* FMDB.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		83C73F0A1C326ADA00FFC730 /* FMDB MacOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 83C73F101C326ADB00FFC730 /* Build configuration list for PBXNativeTarget "FMDB MacOS" */;
+			buildPhases = (
+				83C73F061C326ADA00FFC730 /* Sources */,
+				83C73F071C326ADA00FFC730 /* Frameworks */,
+				83C73F081C326ADA00FFC730 /* Headers */,
+				83C73F091C326ADA00FFC730 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FMDB MacOS";
+			productName = "FMDB MacOS";
+			productReference = 83C73F0B1C326ADA00FFC730 /* FMDB.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		8DD76F960486AA7600D96B5E /* fmdb */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "fmdb" */;
@@ -420,7 +534,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				BF5D042418416BB2008C5AA9 /* PBXTargetDependency */,
+				83C73F2E1C326D2000FFC730 /* PBXTargetDependency */,
 			);
 			name = Tests;
 			productName = Tests;
@@ -452,6 +566,12 @@
 			attributes = {
 				LastUpgradeCheck = 0710;
 				TargetAttributes = {
+					83C73EFD1C326AB000FFC730 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					83C73F0A1C326ADA00FFC730 = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					BF5D041518416BB2008C5AA9 = {
 						TestTargetID = EE4290EE12B42F870088BD94;
 					};
@@ -476,11 +596,27 @@
 				EE4290EE12B42F870088BD94 /* FMDB */,
 				BF5D041518416BB2008C5AA9 /* Tests */,
 				6290CBB4188FE836009790F8 /* FMDB-IOS */,
+				83C73EFD1C326AB000FFC730 /* FMDB iOS */,
+				83C73F0A1C326ADA00FFC730 /* FMDB MacOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		83C73EFC1C326AB000FFC730 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		83C73F091C326ADA00FFC730 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF5D041418416BB2008C5AA9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -501,6 +637,30 @@
 				621721B61892BFE30006691F /* FMDatabasePool.m in Sources */,
 				621721B41892BFE30006691F /* FMDatabaseQueue.m in Sources */,
 				621721B51892BFE30006691F /* FMDatabaseAdditions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		83C73EF91C326AB000FFC730 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83C73F131C326B9400FFC730 /* FMDatabase.m in Sources */,
+				83C73F141C326B9400FFC730 /* FMResultSet.m in Sources */,
+				83C73F151C326B9400FFC730 /* FMDatabaseQueue.m in Sources */,
+				83C73F161C326B9400FFC730 /* FMDatabaseAdditions.m in Sources */,
+				83C73F171C326B9400FFC730 /* FMDatabasePool.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		83C73F061C326ADA00FFC730 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83C73F1E1C326BC100FFC730 /* FMDatabase.m in Sources */,
+				83C73F1F1C326BC100FFC730 /* FMResultSet.m in Sources */,
+				83C73F201C326BC100FFC730 /* FMDatabaseQueue.m in Sources */,
+				83C73F211C326BC100FFC730 /* FMDatabaseAdditions.m in Sources */,
+				83C73F221C326BC100FFC730 /* FMDatabasePool.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -553,10 +713,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		BF5D042418416BB2008C5AA9 /* PBXTargetDependency */ = {
+		83C73F2E1C326D2000FFC730 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = EE4290EE12B42F870088BD94 /* FMDB */;
-			targetProxy = BF5D042318416BB2008C5AA9 /* PBXContainerItemProxy */;
+			target = 83C73F0A1C326ADA00FFC730 /* FMDB MacOS */;
+			targetProxy = 83C73F2D1C326D2000FFC730 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -721,6 +881,167 @@
 			};
 			name = Release;
 		};
+		83C73F031C326AB000FFC730 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = src/fmdb/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.flyingmeat.FMDB-iOS";
+				PRODUCT_NAME = FMDB;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		83C73F041C326AB000FFC730 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = src/fmdb/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.flyingmeat.FMDB-iOS";
+				PRODUCT_NAME = FMDB;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		83C73F111C326ADB00FFC730 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = src/fmdb/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.flyingmeat.FMDB-MacOS";
+				PRODUCT_NAME = FMDB;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		83C73F121C326ADB00FFC730 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = src/fmdb/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.flyingmeat.FMDB-MacOS";
+				PRODUCT_NAME = FMDB;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		BF5D042518416BB2008C5AA9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -853,6 +1174,24 @@
 			buildConfigurations = (
 				6290CBD3188FE837009790F8 /* Debug */,
 				6290CBD4188FE837009790F8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83C73F051C326AB000FFC730 /* Build configuration list for PBXNativeTarget "FMDB iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83C73F031C326AB000FFC730 /* Debug */,
+				83C73F041C326AB000FFC730 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83C73F101C326ADB00FFC730 /* Build configuration list for PBXNativeTarget "FMDB MacOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83C73F111C326ADB00FFC730 /* Debug */,
+				83C73F121C326ADB00FFC730 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB MacOS.xcscheme
+++ b/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB MacOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "83C73F0A1C326ADA00FFC730"
+               BuildableName = "FMDB MacOS.framework"
+               BlueprintName = "FMDB MacOS"
+               ReferencedContainer = "container:fmdb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "83C73F0A1C326ADA00FFC730"
+            BuildableName = "FMDB MacOS.framework"
+            BlueprintName = "FMDB MacOS"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "83C73F0A1C326ADA00FFC730"
+            BuildableName = "FMDB MacOS.framework"
+            BlueprintName = "FMDB MacOS"
+            ReferencedContainer = "container:fmdb.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB MacOS.xcscheme
+++ b/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB MacOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "83C73F0A1C326ADA00FFC730"
-               BuildableName = "FMDB MacOS.framework"
+               BuildableName = "FMDB.framework"
                BlueprintName = "FMDB MacOS"
                ReferencedContainer = "container:fmdb.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "83C73F0A1C326ADA00FFC730"
-            BuildableName = "FMDB MacOS.framework"
+            BuildableName = "FMDB.framework"
             BlueprintName = "FMDB MacOS"
             ReferencedContainer = "container:fmdb.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "83C73F0A1C326ADA00FFC730"
-            BuildableName = "FMDB MacOS.framework"
+            BuildableName = "FMDB.framework"
             BlueprintName = "FMDB MacOS"
             ReferencedContainer = "container:fmdb.xcodeproj">
          </BuildableReference>

--- a/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB iOS.xcscheme
+++ b/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "83C73EFD1C326AB000FFC730"
-               BuildableName = "FMDB iOS.framework"
+               BuildableName = "FMDB.framework"
                BlueprintName = "FMDB iOS"
                ReferencedContainer = "container:fmdb.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "83C73EFD1C326AB000FFC730"
-            BuildableName = "FMDB iOS.framework"
+            BuildableName = "FMDB.framework"
             BlueprintName = "FMDB iOS"
             ReferencedContainer = "container:fmdb.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "83C73EFD1C326AB000FFC730"
-            BuildableName = "FMDB iOS.framework"
+            BuildableName = "FMDB.framework"
             BlueprintName = "FMDB iOS"
             ReferencedContainer = "container:fmdb.xcodeproj">
          </BuildableReference>

--- a/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB iOS.xcscheme
+++ b/fmdb.xcodeproj/xcshareddata/xcschemes/FMDB iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BF5D041518416BB2008C5AA9"
-               BuildableName = "Tests.xctest"
-               BlueprintName = "Tests"
+               BlueprintIdentifier = "83C73EFD1C326AB000FFC730"
+               BuildableName = "FMDB iOS.framework"
+               BlueprintName = "FMDB iOS"
                ReferencedContainer = "container:fmdb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,26 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BF5D041518416BB2008C5AA9"
-               BuildableName = "Tests.xctest"
-               BlueprintName = "Tests"
-               ReferencedContainer = "container:fmdb.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BF5D041518416BB2008C5AA9"
-            BuildableName = "Tests.xctest"
-            BlueprintName = "Tests"
-            ReferencedContainer = "container:fmdb.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -64,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BF5D041518416BB2008C5AA9"
-            BuildableName = "Tests.xctest"
-            BlueprintName = "Tests"
+            BlueprintIdentifier = "83C73EFD1C326AB000FFC730"
+            BuildableName = "FMDB iOS.framework"
+            BlueprintName = "FMDB iOS"
             ReferencedContainer = "container:fmdb.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -82,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BF5D041518416BB2008C5AA9"
-            BuildableName = "Tests.xctest"
-            BlueprintName = "Tests"
+            BlueprintIdentifier = "83C73EFD1C326AB000FFC730"
+            BuildableName = "FMDB iOS.framework"
+            BlueprintName = "FMDB iOS"
             ReferencedContainer = "container:fmdb.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/src/extra/Swift extensions/FMDatabaseVariadic.swift
+++ b/src/extra/Swift extensions/FMDatabaseVariadic.swift
@@ -13,24 +13,26 @@ extension FMDatabase {
     /// This is a rendition of executeQuery that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
+    /// This throws any error that occurs.
+    ///
     /// - parameter sql:     The SQL statement to be used.
     /// - parameter values:  The values to be bound to the ? placeholders
     ///
-    /// - returns:           This returns FMResultSet if successful. Returns nil upon error.
+    /// - returns:           This returns FMResultSet if successful. If unsuccessful, it throws an error.
     
-    func executeQuery(sql:String, _ values: AnyObject...) -> FMResultSet? {
-        return executeQuery(sql, withArgumentsInArray: values as [AnyObject]);
+    func executeQuery(sql:String, _ values: AnyObject...) throws -> FMResultSet {
+        return try executeQuery(sql, values: values as [AnyObject]);
     }
     
     /// This is a rendition of executeUpdate that handles Swift variadic parameters
     /// for the values to be bound to the ? placeholders in the SQL.
     ///
+    /// This throws any error that occurs.
+    ///
     /// - parameter sql:     The SQL statement to be used.
     /// - parameter values:  The values to be bound to the ? placeholders
-    ///
-    /// - returns:            This returns true if successful. Returns false upon error.
     
-    func executeUpdate(sql:String, _ values: AnyObject...) -> Bool {
-        return executeUpdate(sql, withArgumentsInArray: values as [AnyObject]);
+    func executeUpdate(sql:String, _ values: AnyObject...) throws {
+        try executeUpdate(sql, values: values as [AnyObject]);
     }
 }

--- a/src/fmdb/FMDB.h
+++ b/src/fmdb/FMDB.h
@@ -1,3 +1,8 @@
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT double FMDBVersionNumber;
+FOUNDATION_EXPORT const unsigned char FMDBVersionString[];
+
 #import "FMDatabase.h"
 #import "FMResultSet.h"
 #import "FMDatabaseAdditions.h"

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -1,9 +1,4 @@
 #import <Foundation/Foundation.h>
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
 #import "FMResultSet.h"
 #import "FMDatabasePool.h"
 
@@ -77,7 +72,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 
 @interface FMDatabase : NSObject  {
     
-    sqlite3*            _db;
+    void*               _db;
     NSString*           _databasePath;
     BOOL                _logsErrors;
     BOOL                _crashOnErrors;
@@ -213,9 +208,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  `SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE`
  
  The database is opened for reading and writing, and is created if it does not already exist. This is the behavior that is always used for `open` method.
- 
- If vfs is given the value is passed to the vfs parameter of sqlite3_open_v2.
- 
+  
  @return `YES` if successful, `NO` on error.
 
  @see [sqlite3_open_v2()](http://sqlite.org/c3ref/open.html)
@@ -223,10 +216,34 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  @see close
  */
 
-#if SQLITE_VERSION_NUMBER >= 3005000
 - (BOOL)openWithFlags:(int)flags;
+
+/** Opening a new database connection with flags and an optional virtual file system (VFS)
+ 
+ @param flags one of the following three values, optionally combined with the `SQLITE_OPEN_NOMUTEX`, `SQLITE_OPEN_FULLMUTEX`, `SQLITE_OPEN_SHAREDCACHE`, `SQLITE_OPEN_PRIVATECACHE`, and/or `SQLITE_OPEN_URI` flags:
+ 
+ `SQLITE_OPEN_READONLY`
+ 
+ The database is opened in read-only mode. If the database does not already exist, an error is returned.
+ 
+ `SQLITE_OPEN_READWRITE`
+ 
+ The database is opened for reading and writing if possible, or reading only if the file is write protected by the operating system. In either case the database must already exist, otherwise an error is returned.
+ 
+ `SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE`
+ 
+ The database is opened for reading and writing, and is created if it does not already exist. This is the behavior that is always used for `open` method.
+ 
+ @param vfsName   If vfs is given the value is passed to the vfs parameter of sqlite3_open_v2.
+ 
+ @return `YES` if successful, `NO` on error.
+ 
+ @see [sqlite3_open_v2()](http://sqlite.org/c3ref/open.html)
+ @see open
+ @see close
+ */
+
 - (BOOL)openWithFlags:(int)flags vfs:(NSString *)vfsName;
-#endif
 
 /** Closing a database connection
  
@@ -473,7 +490,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 
  */
 
-- (sqlite_int64)lastInsertRowId;
+- (int64_t)lastInsertRowId;
 
 /** The number of rows changed by prior SQL statement.
  
@@ -793,7 +810,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  
  */
 
-- (sqlite3*)sqliteHandle;
+- (void*)sqliteHandle;
 
 
 ///-----------------------------
@@ -857,8 +874,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 - (NSTimeInterval)maxBusyRetryTimeInterval;
 
 
-#if SQLITE_VERSION_NUMBER >= 3007000
-
 ///------------------
 /// @name Save points
 ///------------------
@@ -919,8 +934,6 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  */
 
 - (NSError*)inSavePoint:(void (^)(BOOL *rollback))block;
-
-#endif
 
 ///----------------------------
 /// @name SQLite library status
@@ -998,7 +1011,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  @see [sqlite3_create_function()](http://sqlite.org/c3ref/create_function.html)
  */
 
-- (void)makeFunctionNamed:(NSString*)name maximumArguments:(int)count withBlock:(void (^)(sqlite3_context *context, int argc, sqlite3_value **argv))block;
+- (void)makeFunctionNamed:(NSString*)name maximumArguments:(int)count withBlock:(void (^)(void *context, int argc, void **argv))block;
 
 
 ///---------------------
@@ -1102,7 +1115,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  */
 
 @interface FMStatement : NSObject {
-    sqlite3_stmt *_statement;
+    void *_statement;
     NSString *_query;
     long _useCount;
     BOOL _inUse;
@@ -1125,7 +1138,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  @see [`sqlite3_stmt`](http://www.sqlite.org/c3ref/stmt.html)
  */
 
-@property (atomic, assign) sqlite3_stmt *statement;
+@property (atomic, assign) void *statement;
 
 /** Indication of whether the statement is in use */
 

--- a/src/fmdb/FMDatabaseAdditions.h
+++ b/src/fmdb/FMDatabaseAdditions.h
@@ -209,8 +209,6 @@
 - (BOOL)validateSQL:(NSString*)sql error:(NSError**)error;
 
 
-#if SQLITE_VERSION_NUMBER >= 3007017
-
 ///-----------------------------------
 /// @name Application identifier tasks
 ///-----------------------------------
@@ -252,7 +250,6 @@
  */
 
 - (void)setApplicationIDString:(NSString*)string;
-#endif
 
 #endif
 

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -7,11 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
 
 @class FMDatabase;
 
@@ -160,8 +155,6 @@
 
 - (void)inDeferredTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
-#if SQLITE_VERSION_NUMBER >= 3007000
-
 /** Synchronously perform database operations in pool using save point.
 
  @param block The code to be run on the `FMDatabasePool` pool.
@@ -172,7 +165,6 @@
 */
 
 - (NSError*)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block;
-#endif
 
 @end
 

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -7,11 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
 
 @class FMDatabase;
 
@@ -179,11 +174,9 @@
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-#if SQLITE_VERSION_NUMBER >= 3007000
 // NOTE: you can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock.
 // If you need to nest, use FMDatabase's startSavePointWithName:error: instead.
 - (NSError*)inSavePoint:(void (^)(FMDatabase *db, BOOL *rollback))block;
-#endif
 
 @end
 

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -1,9 +1,4 @@
 #import <Foundation/Foundation.h>
-#if FMDB_SQLITE_STANDALONE
-#import <sqlite3/sqlite3.h>
-#else
-#import <sqlite3.h>
-#endif
 
 #ifndef __has_feature      // Optional.
 #define __has_feature(x) 0 // Compatibility with non-clang compilers.

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -2,6 +2,12 @@
 #import "FMDatabase.h"
 #import "unistd.h"
 
+#if FMDB_SQLITE_STANDALONE
+#import <sqlite3/sqlite3.h>
+#else
+#import <sqlite3.h>
+#endif
+
 @interface FMDatabase ()
 - (void)resultSetDidClose:(FMResultSet *)resultSet;
 @end

--- a/src/fmdb/Info.plist
+++ b/src/fmdb/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.6</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
Gus, here is version 2.6 pull request, which introduces framework support (akin to that of the `swiftFrameworks` branch, though with even more modest changes), as well as taking it the next step and introducing Carthage support (i.e. added two shared targets that build MacOS and iOS frameworks, respectively). I tried to update the change log to indicate the nature of the non-backward compatible change, but if you think we need something more explicit, let me know.

I haven't touched the Cocoapods stuff (other than bumping version), so perhaps we need someone more familiar with Cocoapods take a look at that.

I also haven't touched the static library targets (I'd vote for removing them to eliminate confusion, but that's your call). I'd also suggesting removing the command line target and `main.m`, too, because IMHO that's (a) confusing; and (b) is falling out of date).

On an unrelated topic, the Swift variadic extension for `FMDatabase` predates the `executeUpdate:values:error:` method that we added for Swift 2, so I've changed that it use the `values` rendition and throw errors. It's a non-backward compatible change (it changes this variadic extension to throw errors), but it's a good thing. Frankly, I would advise just removing it altogether, though, as I think the new `try db.executeUpdate("INSERT INTO ...", values ["foo", "bar"])` syntax is sufficiently concise that it eliminates the need for this variadic extension. And variadic methods are so un-Swift (though the language supports it). But, I know you love your variadic methods, so if you want to keep this tweaked extension, I'm fine with that.