### PR TITLE
Improve FTS tokenization performance

### DIFF
--- a/src/extra/fts3/FMDatabase+FTS3.h
+++ b/src/extra/fts3/FMDatabase+FTS3.h
@@ -59,11 +59,13 @@ typedef struct FMTokenizerCursor
 {
     void       *tokenizer;      /* Internal SQLite reference */
     CFStringRef inputString;    /* The input text being tokenized */
-    CFRange     currentRange;   /* The current offset within `inputString` */
+    CFRange     currentRange;   /* The current range within `inputString` */
     CFStringRef tokenString;    /* The contents of the current token */
     CFTypeRef   userObject;     /* Additional state for the cursor */
     int         tokenIndex;     /* Index of next token to be returned */
     UInt8       outputBuf[128]; /* Result for SQLite */
+    CFRange     previousRange;  /* Cached range of previous token within `inputString` */
+    CFRange     previousOffsetRange; /* Cached range of previous token as UTF-8 offset */
 } FMTokenizerCursor;
 
 @protocol FMTokenizerDelegate


### PR DESCRIPTION
- `CFStringGetBytes` was calculating the UTF-8 offset from the beginning of string to current token again and again for each token. The longer the document the longer this operation took. Most tokenizers are sequential, and this repeated calculation was unnecessary
- Started caching last token range and its UTF-8 offset to avoid this repeated calculation.
- Extremely long documents (1 million characters) could take 30-40 seconds to index on a fast machine. Now they are indexed in less than a second
- Non-sequential tokenizers are still supported: cached range is reset if a token does not follow previous token.