### PR TITLE
Fix mismatched-selectors warning

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -321,7 +321,7 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
 - (void)clearCachedStatements {
     
     for (NSMutableSet *statements in [_cachedStatements objectEnumerator]) {
-        [statements makeObjectsPerformSelector:@selector(close)];
+        for (FMStatement *statement in statements.allObjects) [statement close];
     }
     
     [_cachedStatements removeAllObjects];


### PR DESCRIPTION
Avoids the warning:
"Several methods with selector 'close' of mismatched types are found for the @selector expression"