### PR TITLE
Map function for FMResultSet

### DIFF
--- a/FMResultSet Extension.swift
+++ b/FMResultSet Extension.swift
@@ -1,0 +1,18 @@
+//
+//  FMResultSet Extension.swift
+//
+
+import Foundation
+
+extension FMResultSet {
+
+    ///A map function to replace `resultSet.next()`
+    func map<T>(transform: FMResultSet -> T) -> [T] {
+        var results: [T] = []
+        while self.next() {
+            results.append(transform(self))
+        }
+        return results
+    }
+    
+}

--- a/fmdb.xcodeproj/project.pbxproj
+++ b/fmdb.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32A70AAB03705E1F00C91783 /* fmdb_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fmdb_Prefix.pch; path = src/sample/fmdb_Prefix.pch; sourceTree = SOURCE_ROOT; };
 		3354379B19E71096005661F3 /* FMResultSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMResultSetTests.m; sourceTree = "<group>"; };
+		436DA4911C96FE3C00A1B274 /* FMResultSet Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FMResultSet Extension.swift"; sourceTree = "<group>"; };
 		6290CBB5188FE836009790F8 /* libFMDB-IOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libFMDB-IOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6290CBB6188FE836009790F8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6290CBC6188FE837009790F8 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -319,6 +320,7 @@
 			children = (
 				832F502419EC4C6B0087DCBF /* FMDatabaseVariadic.swift */,
 				8352D5AC1A73DCEA003A8E09 /* FMDatabaseAdditionsVariadic.swift */,
+				436DA4911C96FE3C00A1B274 /* FMResultSet Extension.swift */,
 			);
 			name = "Swift extensions";
 			sourceTree = "<group>";


### PR DESCRIPTION
This is an implementation of a generic map function for FMResultSet. So instead of writing
```
let results = db.executeQuery(QUERY, values: nil)
results.next() {
    print(results.stringForColumn(COLUMN)
}
```

One can simply write
```
db.executeQuery(QUERY, values: nil).map { print($0.stringForColumn(COLUMN)) }
```