### PR TITLE
Added support for custom database class and vfsName

### DIFF
--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -39,7 +39,8 @@
     __unsafe_unretained id _delegate;
     
     NSUInteger          _maximumNumberOfDatabasesToCreate;
-    int                 _openFlags;
+	int                 _openFlags;
+	NSString            *_vfsName;
 }
 
 /** Database path */
@@ -57,6 +58,10 @@
 /** Open flags */
 
 @property (atomic, readonly) int openFlags;
+
+/**  Custom virtual file system name */
+
+@property (atomic, copy) NSString *vfsName;
 
 
 ///---------------------
@@ -100,6 +105,26 @@
  */
 
 - (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags;
+
+/** Create pool using path and specified flags.
+
+ @param aPath The file path of the database.
+ @param openFlags Flags passed to the openWithFlags method of the database
+ @param vfsName The name of a custom virtual file system
+
+ @return The `FMDatabasePool` object. `nil` on error.
+ */
+
+- (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags vfs:(NSString *)vfsName;
+
+/** Returns the Class of 'FMDatabase' subclass, that will be used to instantiate database object.
+
+ Subclasses can override this method to return specified Class of 'FMDatabase' subclass.
+
+ @return The Class of 'FMDatabase' subclass, that will be used to instantiate database object.
+ */
+
++ (Class)databaseClass;
 
 ///------------------------------------------------
 /// @name Keeping track of checked in/out databases

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -39,8 +39,8 @@
     __unsafe_unretained id _delegate;
     
     NSUInteger          _maximumNumberOfDatabasesToCreate;
-	int                 _openFlags;
-	NSString            *_vfsName;
+    int                 _openFlags;
+    NSString            *_vfsName;
 }
 
 /** Database path */

--- a/src/fmdb/FMDatabasePool.m
+++ b/src/fmdb/FMDatabasePool.m
@@ -38,7 +38,7 @@
     return FMDBReturnAutoreleased([[self alloc] initWithPath:aPath flags:openFlags]);
 }
 
-- (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags {
+- (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags vfs:(NSString *)vfsName {
     
     self = [super init];
     
@@ -48,9 +48,14 @@
         _databaseInPool     = FMDBReturnRetained([NSMutableArray array]);
         _databaseOutPool    = FMDBReturnRetained([NSMutableArray array]);
         _openFlags          = openFlags;
+		_vfsName			= [vfsName copy];
     }
     
     return self;
+}
+
+- (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags {
+	return [self initWithPath:aPath flags:openFlags vfs:nil];
 }
 
 - (instancetype)initWithPath:(NSString*)aPath
@@ -63,6 +68,9 @@
     return [self initWithPath:nil];
 }
 
++ (Class)databaseClass {
+	return [FMDatabase class];
+}
 
 - (void)dealloc {
     
@@ -128,13 +136,13 @@
                 }
             }
             
-            db = [FMDatabase databaseWithPath:self->_path];
+            db = [[[self class] databaseClass] databaseWithPath:self->_path];
             shouldNotifyDelegate = YES;
         }
         
         //This ensures that the db is opened before returning
 #if SQLITE_VERSION_NUMBER >= 3005000
-        BOOL success = [db openWithFlags:self->_openFlags];
+        BOOL success = [db openWithFlags:self->_openFlags vfs:self->_vfsName];
 #else
         BOOL success = [db open];
 #endif

--- a/src/fmdb/FMDatabasePool.m
+++ b/src/fmdb/FMDatabasePool.m
@@ -48,14 +48,14 @@
         _databaseInPool     = FMDBReturnRetained([NSMutableArray array]);
         _databaseOutPool    = FMDBReturnRetained([NSMutableArray array]);
         _openFlags          = openFlags;
-		_vfsName			= [vfsName copy];
+        _vfsName            = [vfsName copy];
     }
     
     return self;
 }
 
 - (instancetype)initWithPath:(NSString*)aPath flags:(int)openFlags {
-	return [self initWithPath:aPath flags:openFlags vfs:nil];
+    return [self initWithPath:aPath flags:openFlags vfs:nil];
 }
 
 - (instancetype)initWithPath:(NSString*)aPath
@@ -69,7 +69,7 @@
 }
 
 + (Class)databaseClass {
-	return [FMDatabase class];
+    return [FMDatabase class];
 }
 
 - (void)dealloc {

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -65,6 +65,7 @@
     dispatch_queue_t    _queue;
     FMDatabase          *_db;
     int                 _openFlags;
+	NSString            *_vfsName;
 }
 
 /** Path of database */
@@ -74,6 +75,10 @@
 /** Open flags */
 
 @property (atomic, readonly) int openFlags;
+
+/**  Custom virtual file system name */
+
+@property (atomic, copy) NSString *vfsName;
 
 ///----------------------------------------------------
 /// @name Initialization, opening, and closing of queue

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -65,7 +65,7 @@
     dispatch_queue_t    _queue;
     FMDatabase          *_db;
     int                 _openFlags;
-	NSString            *_vfsName;
+    NSString            *_vfsName;
 }
 
 /** Path of database */

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -83,7 +83,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
         _queue = dispatch_queue_create([[NSString stringWithFormat:@"fmdb.%@", self] UTF8String], NULL);
         dispatch_queue_set_specific(_queue, kDispatchQueueSpecificKey, (__bridge void *)self, NULL);
         _openFlags = openFlags;
-		_vfsName = [vfsName copy];
+        _vfsName = [vfsName copy];
     }
     
     return self;

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -34,6 +34,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 
 @synthesize path = _path;
 @synthesize openFlags = _openFlags;
+@synthesize vfsName = _vfsName;
 
 + (instancetype)databaseQueueWithPath:(NSString*)aPath {
     
@@ -82,6 +83,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
         _queue = dispatch_queue_create([[NSString stringWithFormat:@"fmdb.%@", self] UTF8String], NULL);
         dispatch_queue_set_specific(_queue, kDispatchQueueSpecificKey, (__bridge void *)self, NULL);
         _openFlags = openFlags;
+		_vfsName = [vfsName copy];
     }
     
     return self;
@@ -128,10 +130,10 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 
 - (FMDatabase*)database {
     if (!_db) {
-        _db = FMDBReturnRetained([FMDatabase databaseWithPath:_path]);
+       _db = FMDBReturnRetained([[[self class] databaseClass] databaseWithPath:_path]);
         
 #if SQLITE_VERSION_NUMBER >= 3005000
-        BOOL success = [_db openWithFlags:_openFlags];
+        BOOL success = [_db openWithFlags:_openFlags vfs:_vfsName];
 #else
         BOOL success = [_db open];
 #endif


### PR DESCRIPTION
FMDatabasePool can now be subclassed to use a subclass of FMDatabase.
FMDatabasePool initializer now accepts a custom vfsName.