### PR TITLE
Replacement for #401: Update podspec for SQLCipher+fts3

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -7,7 +7,12 @@ Pod::Spec.new do |s|
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
   s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => "#{s.version}" }
   s.requires_arc = true
-  s.default_subspec = 'standard'  
+  s.default_subspec = 'standard'
+
+  s.subspec 'common' do |ss|
+    ss.source_files = 'src/fmdb/FM*.{h,m}'
+    ss.exclude_files = 'src/fmdb.m'
+  end
 
   # use the built-in library version of sqlite3
   s.subspec 'standard' do |ss|
@@ -26,24 +31,21 @@ Pod::Spec.new do |s|
   s.subspec 'standalone' do |ss|
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE' }
     ss.dependency 'sqlite3'
-    ss.source_files = 'src/fmdb/FM*.{h,m}'
-    ss.exclude_files = 'src/fmdb.m'
-  end
-
-  # build with FTS support and custom FTS tokenizer source files
+    ss.dependency 'FMDB/common'
+	end
+	
+  # build the latest stable version of sqlite3 
+	# with FTS support and custom FTS tokenizer source files
   s.subspec 'standalone-fts' do |ss|
-    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE' }
-    ss.source_files = 'src/fmdb/FM*.{h,m}', 'src/extra/fts3/*.{h,m}'
-    ss.exclude_files = 'src/fmdb.m'
+    ss.dependency 'FMDB/standalone'
     ss.dependency 'sqlite3/fts'
+    ss.source_files = 'src/extra/fts3/*.{h,m}'
   end
 
   # use SQLCipher and enable -DSQLITE_HAS_CODEC flag
   s.subspec 'SQLCipher' do |ss|
     ss.dependency 'SQLCipher'
-    ss.source_files = 'src/fmdb/FM*.{h,m}'
-    ss.exclude_files = 'src/fmdb.m'
-    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }
-  end
-  
+  	ss.dependency 'FMDB/common'
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }		
+  end  
 end

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -47,5 +47,12 @@ Pod::Spec.new do |s|
     ss.dependency 'SQLCipher'
   	ss.dependency 'FMDB/common'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }		
+		
+		# FMDB/SQLCipher/FTS subspec, which uses SQLCipher 
+		# and adds FTS support + custom FTS tokenizer source files
+    ss.subspec 'FTS' do |sss|
+        sss.dependency 'SQLCipher/fts'
+        sss.dependency 'FMDB/FTS'
+    end
   end  
 end


### PR DESCRIPTION
It turned out to be significantly easier and clearer to just create a new branch and pull request for this fix. The first commit just simplifies the podspec to use dependencies to deduplicate code; the second adds FMDB/SQLCipher/FTS3