### PR TITLE
Re-add the ability to interrupt a query in progress

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -734,6 +734,15 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 
 - (void)setShouldCacheStatements:(BOOL)value;
 
+/** Interupt pending database operation
+ 
+ This method causes any pending database operation to abort and return at its earliest opportunity
+ 
+ @return `YES` on success; `NO` on failure. If failed, you can call `<lastError>`, `<lastErrorCode>`, or `<lastErrorMessage>` for diagnostic information regarding the failure.
+ 
+ */
+
+- (BOOL)interrupt;
 
 ///-------------------------
 /// @name Encryption methods

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1077,6 +1077,12 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
     if (SQLITE_DONE == rc) {
         // all is well, let's return.
     }
+    else if (SQLITE_INTERRUPT == rc) {
+        if (_logsErrors) {
+            NSLog(@"Error calling sqlite3_step. Query was interrupted (%d: %s) SQLITE_INTERRUPT", rc, sqlite3_errmsg(_db));
+            NSLog(@"DB Query: %@", sql);
+        }
+    }
     else if (rc == SQLITE_ROW) {
         NSString *message = [NSString stringWithFormat:@"A executeUpdate is being called with a query string '%@'", sql];
         if (_logsErrors) {
@@ -1299,6 +1305,15 @@ int FMDBExecuteBulkSQLCallback(void *theBlockAsVoid, int columns, char **values,
 
 - (BOOL)inTransaction {
     return _inTransaction;
+}
+
+- (BOOL)interrupt
+{
+    if (_db) {
+        sqlite3_interrupt([self sqliteHandle]);
+        return YES;
+    }
+    return NO;
 }
 
 static NSString *FMDBEscapeSavePointName(NSString *savepointName) {

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -145,6 +145,10 @@
 
 - (void)close;
 
+/** Interupt pending database operation. */
+
+- (void)interrupt;
+
 ///-----------------------------------------------
 /// @name Dispatching database operations to queue
 ///-----------------------------------------------

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -128,6 +128,11 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
     FMDBRelease(self);
 }
 
+- (void)interrupt
+{
+    [[self database] interrupt];
+}
+
 - (FMDatabase*)database {
     if (!_db) {
        _db = FMDBReturnRetained([[[self class] databaseClass] databaseWithPath:_path]);


### PR DESCRIPTION
Marek Serafin's [cbc4188] was previously applied, but the changes were silently removed in [59f8d63]. This reapplies those changes. 

(Theoretically this should be a cherrypick, but I ended up in an hourlong fight with git over it which I think are related to whitespace changes between the 2014 commit and now).