### PR TITLE
Expose `sqlite3_extended_errcode`

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -323,7 +323,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  
  @note This technique supports the use of `?` placeholders in the SQL, automatically binding any supplied value parameters to those placeholders. This approach is more robust than techniques that entail using `stringWithFormat` to manually build SQL statements, which can be problematic if the values happened to include any characters that needed to be quoted.
  
- @note If you want to use this from Swift, please note that you must include `FMDatabaseVariadic.swift` in your project. Without that, you cannot use this method directly, and instead have to use methods such as `<executeUpdate:withArgumentsInArray:>`.
+ @note You cannot use this method from Swift due to incompatibilities between Swift and Objective-C variadic implementations. Consider using `<executeUpdate:values:>` instead.
  */
 
 - (BOOL)executeUpdate:(NSString*)sql, ...;
@@ -527,7 +527,7 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
  @see [`FMResultSet next`](<[FMResultSet next]>)
  @see [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html)
  
- @note If you want to use this from Swift, please note that you must include `FMDatabaseVariadic.swift` in your project. Without that, you cannot use this method directly, and instead have to use methods such as `<executeQuery:withArgumentsInArray:>`.
+ @note You cannot use this method from Swift due to incompatibilities between Swift and Objective-C variadic implementations. Consider using `<executeQuery:values:>` instead.
  */
 
 - (FMResultSet *)executeQuery:(NSString*)sql, ...;

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -834,16 +834,32 @@ typedef int(^FMDBExecuteStatementsCallbackBlock)(NSDictionary *resultsDictionary
 /** Last error code
  
  Returns the numeric result code or extended result code for the most recent failed SQLite API call associated with a database connection. If a prior API call failed but the most recent API call succeeded, this return value is undefined.
-
+ 
  @return Integer value of the last error code.
-
+ 
  @see [sqlite3_errcode()](http://sqlite.org/c3ref/errcode.html)
  @see lastErrorMessage
  @see lastError
-
+ 
  */
 
 - (int)lastErrorCode;
+
+/** Last extended error code
+ 
+ Returns the numeric extended result code for the most recent failed SQLite API call associated with a database connection. If a prior API call failed but the most recent API call succeeded, this return value is undefined.
+ 
+ @return Integer value of the last extended error code.
+ 
+ @see [sqlite3_errcode()](http://sqlite.org/c3ref/errcode.html)
+ @see [2. Primary Result Codes versus Extended Result Codes](http://sqlite.org/rescode.html#primary_result_codes_versus_extended_result_codes)
+ @see [5. Extended Result Code List](http://sqlite.org/rescode.html#extrc)
+ @see lastErrorMessage
+ @see lastError
+ 
+ */
+
+- (int)lastExtendedErrorCode;
 
 /** Had error
 

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -500,6 +500,10 @@ static int FMDBDatabaseBusyHandler(void *f, int count) {
     return sqlite3_errcode(_db);
 }
 
+- (int)lastExtendedErrorCode {
+    return sqlite3_extended_errcode(_db);
+}
+
 - (NSError*)errorWithMessage:(NSString*)message {
     NSDictionary* errorMessage = [NSDictionary dictionaryWithObject:message forKey:NSLocalizedDescriptionKey];
     


### PR DESCRIPTION
Pursuant to issue https://github.com/ccgus/fmdb/issues/535, we may want to expose `sqlite3_extended_errcode`.

Also, unrelated, updated notes for variadic `FMDatabase` methods, to remove the advise to add the variadic extension. Better to just use `executeQuery:values:`, IMHO.