### PR TITLE
Update README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,7 +53,8 @@ An `FMDatabase` is created with a path to a SQLite database file.  This path can
 (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: http://www.sqlite.org/inmemorydb.html)
 
 ```objc
-FMDatabase *db = [FMDatabase databaseWithPath:@"/tmp/tmp.db"];
+NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"tmp.db"];
+FMDatabase *db = [FMDatabase databaseWithPath:path];
 ```
 
 ### Opening
@@ -62,7 +63,8 @@ Before you can interact with the database, it must be opened.  Opening fails if 
 
 ```objc
 if (![db open]) {
-    [db release];
+    // [db release];   // uncomment this line in manual referencing code; in ARC, this is not necessary/permitted
+    db = nil;
     return;
 }
 ```


### PR DESCRIPTION
1. Remove hard coded `/tmp` folder. At the very least, use `NSTemporaryDirectory`. You can also use `URLForDirectory` with `NSItemReplacementDirectory`, but I agree [with NSHipster](http://nshipster.com/nstemporarydirectory/) that `NSTemporaryDirectory` is fine.
2. Comment out `[db release]` because for 99% of users, now, this isn't appropriate. But `nil` the pointer either way (in MRC, eliminate dangling pointer reference, in ARC, remove your strong reference).

This is to forestall confusions, such as those raised by roblav96 in issue https://github.com/ccgus/fmdb/issues/538.