### PR TITLE
Only log errors if `logsErrors` is set

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -3,6 +3,18 @@ Zip, nada, zilch.  Got any ideas?
 
 If you would like to contribute some code ... awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add the necessary of tests for your new code to tests target.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
 
+2016.10.21
+    Changed all `NSLog` statements that report errors to do so conditionally, only if `logsErrors` is set.
+
+2016.09.22
+    Added `lastExtendedErrorCode`.
+
+2016.06.08
+    Added `interrupt`.
+
+2016.04.06
+    Added virtual file support.
+
 2015.12.28
     Removed `sqlite3.h` from the headers to simplify incorporation of FMDB into a framework. This eliminates the dreaded "non-modular headers" error in frameworks.
 

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.6.2'
+  s.version = '2.6.3'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# FMDB v2.6.2
+# FMDB v2.6.3
 
 This is an Objective-C wrapper around SQLite: http://sqlite.org/
 

--- a/Tests/FMDatabaseTests.m
+++ b/Tests/FMDatabaseTests.m
@@ -840,7 +840,7 @@
 }
 
 - (void)testVersionNumber {
-    XCTAssertTrue([FMDatabase FMDBVersion] == 0x0262); // this is going to break everytime we bump it.
+    XCTAssertTrue([FMDatabase FMDBVersion] == 0x0263); // this is going to break everytime we bump it.
 }
 
 - (void)testExecuteStatements

--- a/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
+++ b/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
@@ -60,14 +60,18 @@ int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
     // only attempt to load an on-disk representation for an in-memory database
     if ( self->_databasePath != nil ) 
     {
-        NSLog(@"Database is not an in-memory representation." );
+        if (_logsErrors) {
+            NSLog(@"Database is not an in-memory representation." );
+        }
         return NO;
     }
     
     // and only if the database is open
     if ( self->_db == nil ) 
     {
-        NSLog(@"Invalid database connection." );
+        if (_logsErrors) {
+            NSLog(@"Invalid database connection." );
+        }
         return NO;
     }
     
@@ -80,14 +84,18 @@ int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
     // only attempt to save an on-disk representation for an in-memory database
     if ( self->_databasePath != nil )
     {
-        NSLog(@"Database is not an in-memory representation." );
+        if (_logsErrors) {
+            NSLog(@"Database is not an in-memory representation." );
+        }
         return NO;
     }
     
     // and only if the database is open
     if ( self->_db == nil ) 
     {
-        NSLog(@"Invalid database connection." );
+        if (_logsErrors) {
+            NSLog(@"Invalid database connection." );
+        }
         return NO;
     }
     

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -73,7 +73,7 @@
 }
 
 + (NSString*)FMDBUserVersion {
-    return @"2.6.2";
+    return @"2.6.3";
 }
 
 // returns 0x0240 for version 2.4.  This makes it super easy to do things like:

--- a/src/fmdb/FMDatabaseAdditions.m
+++ b/src/fmdb/FMDatabaseAdditions.m
@@ -180,7 +180,7 @@ return ret;
 
 - (void)setApplicationIDString:(NSString*)s {
 #if SQLITE_VERSION_NUMBER >= 3007017
-    if ([s length] != 4) {
+    if ([s length] != 4 && _logsErrors) {
         NSLog(@"setApplicationIDString: string passed is not exactly 4 chars long. (was %ld)", [s length]);
     }
     

--- a/src/fmdb/FMDatabasePool.m
+++ b/src/fmdb/FMDatabasePool.m
@@ -131,7 +131,9 @@
                 NSUInteger currentCount = [self->_databaseOutPool count] + [self->_databaseInPool count];
                 
                 if (currentCount >= self->_maximumNumberOfDatabasesToCreate) {
-                    NSLog(@"Maximum number of databases (%ld) has already been reached!", (long)currentCount);
+                    if (db.logsErrors) {
+                        NSLog(@"Maximum number of databases (%ld) has already been reached!", (long)currentCount);
+                    }
                     return;
                 }
             }
@@ -163,7 +165,9 @@
             }
         }
         else {
-            NSLog(@"Could not open up the database at path %@", self->_path);
+            if (db.logsErrors) {
+                NSLog(@"Could not open up the database at path %@", self->_path);
+            }
             db = 0x00;
         }
     }];

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -73,7 +73,9 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
         BOOL success = [_db open];
 #endif
         if (!success) {
-            NSLog(@"Could not create database queue for path %@", aPath);
+            if (_db.logsErrors) {
+                NSLog(@"Could not create database queue for path %@", aPath);
+            }
             FMDBRelease(self);
             return 0x00;
         }
@@ -143,7 +145,9 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
         BOOL success = [_db open];
 #endif
         if (!success) {
-            NSLog(@"FMDatabaseQueue could not reopen database for path %@", _path);
+            if (_db.logsErrors) {
+                NSLog(@"FMDatabaseQueue could not reopen database for path %@", _path);
+            }
             FMDBRelease(_db);
             _db  = 0x00;
             return 0x00;
@@ -167,13 +171,17 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
         block(db);
         
         if ([db hasOpenResultSets]) {
-            NSLog(@"Warning: there is at least one open result set around after performing [FMDatabaseQueue inDatabase:]");
+            if (db.logsErrors) {
+                NSLog(@"Warning: there is at least one open result set around after performing [FMDatabaseQueue inDatabase:]");
+            }
             
 #if defined(DEBUG) && DEBUG
             NSSet *openSetCopy = FMDBReturnAutoreleased([[db valueForKey:@"_openResultSets"] copy]);
             for (NSValue *rsInWrappedInATastyValueMeal in openSetCopy) {
                 FMResultSet *rs = (FMResultSet *)[rsInWrappedInATastyValueMeal pointerValue];
-                NSLog(@"query: '%@'", [rs query]);
+                if (db.logsErrors) {
+                    NSLog(@"query: '%@'", [rs query]);
+                }
             }
 #endif
         }

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -114,7 +114,7 @@
         
         return FMDBReturnAutoreleased([dict copy]);
     }
-    else {
+    else if (_parentDB.logsErrors) {
         NSLog(@"Warning: There seem to be no columns in this set.");
     }
     
@@ -142,7 +142,7 @@
         
         return dict;
     }
-    else {
+    else if (_parentDB.logsErrors) {
         NSLog(@"Warning: There seem to be no columns in this set.");
     }
     
@@ -161,8 +161,10 @@
     int rc = sqlite3_step([_statement statement]);
     
     if (SQLITE_BUSY == rc || SQLITE_LOCKED == rc) {
-        NSLog(@"%s:%d Database busy (%@)", __FUNCTION__, __LINE__, [_parentDB databasePath]);
-        NSLog(@"Database busy");
+        if (_parentDB.logsErrors) {
+            NSLog(@"%s:%d Database busy (%@)", __FUNCTION__, __LINE__, [_parentDB databasePath]);
+            NSLog(@"Database busy");
+        }
         if (outErr) {
             *outErr = [_parentDB lastError];
         }
@@ -171,14 +173,18 @@
         // all is well, let's return.
     }
     else if (SQLITE_ERROR == rc) {
-        NSLog(@"Error calling sqlite3_step (%d: %s) rs", rc, sqlite3_errmsg([_parentDB sqliteHandle]));
+        if (_parentDB.logsErrors) {
+            NSLog(@"Error calling sqlite3_step (%d: %s) rs", rc, sqlite3_errmsg([_parentDB sqliteHandle]));
+        }
         if (outErr) {
             *outErr = [_parentDB lastError];
         }
     }
     else if (SQLITE_MISUSE == rc) {
         // uh oh.
-        NSLog(@"Error calling sqlite3_step (%d: %s) rs", rc, sqlite3_errmsg([_parentDB sqliteHandle]));
+        if (_parentDB.logsErrors) {
+            NSLog(@"Error calling sqlite3_step (%d: %s) rs", rc, sqlite3_errmsg([_parentDB sqliteHandle]));
+        }
         if (outErr) {
             if (_parentDB) {
                 *outErr = [_parentDB lastError];
@@ -194,7 +200,9 @@
     }
     else {
         // wtf?
-        NSLog(@"Unknown error calling sqlite3_step (%d: %s) rs", rc, sqlite3_errmsg([_parentDB sqliteHandle]));
+        if (_parentDB.logsErrors) {
+            NSLog(@"Unknown error calling sqlite3_step (%d: %s) rs", rc, sqlite3_errmsg([_parentDB sqliteHandle]));
+        }
         if (outErr) {
             *outErr = [_parentDB lastError];
         }
@@ -221,7 +229,9 @@
         return [n intValue];
     }
     
-    NSLog(@"Warning: I could not find the column named '%@'.", columnName);
+    if (_parentDB.logsErrors) {
+        NSLog(@"Warning: I could not find the column named '%@'.", columnName);
+    }
     
     return -1;
 }

--- a/src/fmdb/Info.plist
+++ b/src/fmdb/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.2</string>
+	<string>2.6.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Pursuant to issue https://github.com/ccgus/fmdb/issues/542, I've updated code to only perform error logging if `logsErrors` is set.

I also updated CHANGES document to reflect some changes over the last few months and I bumped version number so that Carthage and CocoaPods users would pick up this change.
