### PR TITLE
Patched minor compilation warning for NDEBUG-defined builds

### DIFF
--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -154,10 +154,12 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 }
 
 - (void)inDatabase:(void (^)(FMDatabase *db))block {
+#ifndef NDEBUG
     /* Get the currently executing queue (which should probably be nil, but in theory could be another DB queue
      * and then check it against self to make sure we're not about to deadlock. */
     FMDatabaseQueue *currentSyncQueue = (__bridge id)dispatch_get_specific(kDispatchQueueSpecificKey);
     assert(currentSyncQueue != self && "inDatabase: was called reentrantly on the same queue, which would lead to a deadlock");
+#endif
     
     FMDBRetain(self);
     


### PR DESCRIPTION
Compilation warning: `unused variable `**`currentSyncQueue`**

I've rather used `#ifndef NDEBUG` clause because neither `DEBUG` nor `NDEBUG` need to be defined in the environment and `assert()` is effectively defined the same way in `assert.h`. 