### PR TITLE
Update SQLCipher import statement

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -5,7 +5,7 @@
 #if FMDB_SQLITE_STANDALONE
 #import <sqlite3/sqlite3.h>
 #else
-#import <sqlite3.h>
+#import <SQLCipher/sqlite3.h>
 #endif
 
 @interface FMDatabase () {


### PR DESCRIPTION
Xcode 9 creates a warning error when attempting to build FMDB. 
![image](https://user-images.githubusercontent.com/6520870/27089068-637063d6-5027-11e7-9cb0-3de3176c4907.png)

This warning is referenced by Issue #591.
Updating the import statement in FMDatabase resolves the warning.