### PR TITLE
Refine close logic

### DIFF
--- a/Tests/FMDatabaseQueueTests.m
+++ b/Tests/FMDatabaseQueueTests.m
@@ -354,4 +354,19 @@
     
 }
 
+- (void)testClose
+{
+    [self.queue inDatabase:^(FMDatabase *adb) {
+        XCTAssertTrue([adb executeUpdate:@"CREATE TABLE close_test (a INTEGER)"]);
+        XCTAssertTrue([adb executeUpdate:@"INSERT INTO close_test VALUES (1)"]);
+        
+        [adb close];
+    }];
+    
+    [self.queue inDatabase:^(FMDatabase *adb) {
+        FMResultSet *ars = [adb executeQuery:@"select * from close_test"];
+        XCTAssertNotNil(ars);
+    }];
+}
+
 @end

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -261,6 +261,8 @@ NS_ASSUME_NONNULL_END
     while (retry);
     
     _db = nil;
+    _isOpen = false;
+    
     return YES;
 }
 

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -156,8 +156,10 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 }
 
 - (FMDatabase*)database {
-    if (!_db) {
-       _db = FMDBReturnRetained([[[self class] databaseClass] databaseWithPath:_path]);
+    if (![_db isOpen]) {
+        if (!_db) {
+           _db = FMDBReturnRetained([[[self class] databaseClass] databaseWithPath:_path]);
+        }
         
 #if SQLITE_VERSION_NUMBER >= 3005000
         BOOL success = [_db openWithFlags:_openFlags vfs:_vfsName];


### PR DESCRIPTION
- If you call `[db close]`, it should reset `isOpen` to false;
- When you try to use `[queue database]`, it should not only check that the `FMDatabase` is non-`nil`, but also whether the database `isOpen` or not;
- Added `testClose` test to `FMDatabaseQueue` logic if the queue's `FMDatabase` was closed.