### PR TITLE
Fix for 'This function declaration is not a prototype'.

### DIFF
--- a/src/sample/main.m
+++ b/src/sample/main.m
@@ -10,9 +10,9 @@
 #define FMDBQuickCheck(SomeBool) { if (!(SomeBool)) { NSLog(@"Failure on line %d", __LINE__); abort(); } }
 
 void testPool(NSString *dbPath);
-void testDateFormat();
-void FMDBReportABugFunction();
-void testStatementCaching();
+void testDateFormat(void);
+void FMDBReportABugFunction(void);
+void testStatementCaching(void);
 
 int main (int argc, const char * argv[]) {
     


### PR DESCRIPTION
Allows sample code to compile via Xcode 9.2 targeting macOS.