### PR TITLE
Fixes an issue with double/nsnumber precision

### DIFF
--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -300,6 +300,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSData * _Nullable)dataForColumnIndex:(int)columnIdx;
 
+/** Result set `NSDecimalNumber` value for column.
+ 
+ @param columnName `NSString` value of the name of the column.
+ 
+ @return `NSDecimalNumber` value of the result set's column.
+ 
+ */
+
+- (NSDecimalNumber * __nullable)decimalForColumn: (NSString *)columnName;
+
+
+/** Result set `NSDecimalNumber` value for column.
+ 
+ @param columnIdx Zero-based index for column.
+ 
+ @return `NSDecimalNumber` value of the result set's column.
+ 
+ */
+
+- (NSDecimalNumber * __nullable)decimalForColumnIndex:(int)columnIdx;
+
+
 /** Result set `(const unsigned char *)` value for column.
 
  @param columnName `NSString` value of the name of the column.

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -333,6 +333,16 @@
 }
 
 
+- (NSDecimalNumber*)decimalForColumn: (NSString *)columnName {
+    return [self decimalForColumnIndex:[self columnIndexForName:columnName]];
+}
+
+- (NSDecimalNumber*)decimalForColumnIndex:(int)columnIdx {
+    NSString * temp = [self stringForColumnIndex: columnIdx];
+    return [[NSDecimalNumber alloc] initWithString: temp];
+}
+
+
 - (NSData*)dataNoCopyForColumn:(NSString*)columnName {
     return [self dataNoCopyForColumnIndex:[self columnIndexForName:columnName]];
 }
@@ -390,8 +400,7 @@
         returnValue = [NSNumber numberWithLongLong:[self longLongIntForColumnIndex:columnIdx]];
     }
     else if (columnType == SQLITE_FLOAT) {
-        NSString * temp = [self stringForColumnIndex: columnIdx];
-        returnValue = [[NSDecimalNumber alloc] initWithString: temp];
+        returnValue = [NSNumber numberWithDouble:[self doubleForColumnIndex:columnIdx]];
     }
     else if (columnType == SQLITE_BLOB) {
         returnValue = [self dataForColumnIndex:columnIdx];
@@ -428,6 +437,5 @@
 - (id)objectForKeyedSubscript:(NSString *)columnName {
     return [self objectForColumn:columnName];
 }
-
 
 @end

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -390,7 +390,8 @@
         returnValue = [NSNumber numberWithLongLong:[self longLongIntForColumnIndex:columnIdx]];
     }
     else if (columnType == SQLITE_FLOAT) {
-        returnValue = [NSNumber numberWithDouble:[self doubleForColumnIndex:columnIdx]];
+        NSString * temp = [self stringForColumnIndex: columnIdx];
+        returnValue = [[NSDecimalNumber alloc] initWithString: temp];
     }
     else if (columnType == SQLITE_BLOB) {
         returnValue = [self dataForColumnIndex:columnIdx];


### PR DESCRIPTION
Running query:
select round(0.7263,4);

Using
returnValue = [NSNumber numberWithDouble:[self doubleForColumnIndex:columnIdx]];

Results into 0.7262999999999999. This fix gets a string and passes this to a NSDecimalNumber which handles the precision better.