### PR TITLE
Always use inDatabase: in FMDatabaseQueue. Respect crashOnErrors for open

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -175,6 +175,9 @@ NS_ASSUME_NONNULL_END
 
     int err = sqlite3_open([self sqlitePath], (sqlite3**)&_db );
     if(err != SQLITE_OK) {
+        if (_crashOnErrors) {
+            NSAssert(false, @"The FMDatabase could not be opened (err: %d) at path: %s", err, [self sqlitePath]);
+        }
         NSLog(@"error opening!: %d", err);
         return NO;
     }
@@ -209,6 +212,9 @@ NS_ASSUME_NONNULL_END
     
     int err = sqlite3_open_v2([self sqlitePath], (sqlite3**)&_db, flags, [vfsName UTF8String]);
     if(err != SQLITE_OK) {
+        if (_crashOnErrors) {
+            NSAssert(false, @"The FMDatabase could not be opened (err: %d) at path: %s", err, [self sqlitePath]);
+        }
         NSLog(@"error opening!: %d", err);
         return NO;
     }


### PR DESCRIPTION
In our code, we use a similar `dispatch_get_specific` technique to guard against deadlock. When I realized this, I was hoping I could just use what's built into FMDB instead. However, It appears not all calls go through `inDatabase:`, which means those other calls could deadlock un-knowlingly (or at least without making much noise).

In doing that, I also realized that you could conceivably call `close` on an `FMDatabaseQueue` and then call `inDatabase:` and have the `[self database]` fail to re-open the database and call the block with a `nil` db, which would break the nullability guarantee of `nonnull` as described in `FMDatabaseQueue.h`. This isn't a big deal in Obj-C, but in Swift it'll cause crash. I fixed it to bail out early and not call the block if the re-open fails. I also added `crashOnErrors` support to the `open` methods in `FMDatabase` to make this scenario hard to miss in debug.

After writing this, it occurs to me that there could have been some reason for not `re-using` `inDatabase:` everywhere. If that's the case, I'm open to refactoring this in a different way to accomplish the same goal. Thanks!