### PR TITLE
Update nullability annotations for `-[FMDatabase getSchema]` and `-[FMDatabase getTableSchema]`

### DIFF
--- a/src/fmdb/FMDatabaseAdditions.h
+++ b/src/fmdb/FMDatabaseAdditions.h
@@ -142,7 +142,7 @@ NS_ASSUME_NONNULL_BEGIN
  @see [SQLite File Format](http://www.sqlite.org/fileformat.html)
  */
 
-- (FMResultSet *)getSchema;
+- (FMResultSet * _Nullable)getSchema;
 
 /** The schema of the database.
 
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  @see [table_info](http://www.sqlite.org/pragma.html#pragma_table_info)
  */
 
-- (FMResultSet*)getTableSchema:(NSString*)tableName;
+- (FMResultSet * _Nullable)getTableSchema:(NSString*)tableName;
 
 /** Test to see if particular column exists for particular table in database
  

--- a/src/fmdb/FMDatabaseAdditions.m
+++ b/src/fmdb/FMDatabaseAdditions.m
@@ -82,7 +82,7 @@ return ret;
  get table with list of tables: result colums: type[STRING], name[STRING],tbl_name[STRING],rootpage[INTEGER],sql[STRING]
  check if table exist in database  (patch from OZLB)
 */
-- (FMResultSet*)getSchema {
+- (FMResultSet * _Nullable)getSchema {
     
     //result colums: type[STRING], name[STRING],tbl_name[STRING],rootpage[INTEGER],sql[STRING]
     FMResultSet *rs = [self executeQuery:@"SELECT type, name, tbl_name, rootpage, sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type != 'meta' AND name NOT LIKE 'sqlite_%' ORDER BY tbl_name, type DESC, name"];
@@ -93,7 +93,7 @@ return ret;
 /* 
  get table schema: result colums: cid[INTEGER], name,type [STRING], notnull[INTEGER], dflt_value[],pk[INTEGER]
 */
-- (FMResultSet*)getTableSchema:(NSString*)tableName {
+- (FMResultSet * _Nullable)getTableSchema:(NSString*)tableName {
     
     //result colums: cid[INTEGER], name,type [STRING], notnull[INTEGER], dflt_value[],pk[INTEGER]
     FMResultSet *rs = [self executeQuery:[NSString stringWithFormat: @"pragma table_info('%@')", tableName]];


### PR DESCRIPTION
The schema functions return the result of calling `-[FMDatabase executeQuery:withArgumentsInArray:orDictionary:orVAList:]`

Since `-[FMDatabase executeQuery:withArgumentsInArray:orDictionary:orVAList:]` can return nil on error, the type annotation of these functions should match that.

The function doc also mentions that this function can return nil:

>  @return `FMResultSet` of schema; `nil` on error.

This is important for Swift, as attempting to access a nil result which is currently typed as `FMResultSet` (instead of `FMResultSet?) will crash.