### PR TITLE
join issue: in  FMResultSet

### DIFF
--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -439,6 +439,14 @@ If you don't, you're going to be in a world of hurt when you try and use the dat
  */
 
 @property (nonatomic, readonly, nullable) NSDictionary *resultDictionary;
+
+
+/**
+ Returns a dictionary of the row results mapped to case sensitive keys of the column names.
+ take care of the condition :  join two tables, and they share some column names, in some cases, we may get <Nsnull> for these columns.
+ */
+@property (nonatomic, readonly, nullable) NSDictionary *fat_resDictionary;
+
  
 /** Returns a dictionary of the row results
  

--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -153,6 +153,32 @@
     return nil;
 }
 
+-(NSDictionary *)fat_resDictionary {
+    NSUInteger num_cols = (NSUInteger)sqlite3_data_count([_statement statement]);
+    
+    if (num_cols > 0) {
+        NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:num_cols];
+        
+        int columnCount = sqlite3_column_count([_statement statement]);
+        
+        int columnIdx = 0;
+        for (columnIdx = 0; columnIdx < columnCount; columnIdx++) {
+            
+            NSString *columnName = [NSString stringWithUTF8String:sqlite3_column_name([_statement statement], columnIdx)];
+            id objectValue = [self objectForColumnIndex:columnIdx];
+            // make sure we have a non <NSNull> value,
+            if (!dict[columnName] || objectValue != [NSNull null]) {
+                [dict setObject:objectValue forKey:columnName];
+            }
+        }
+        return dict;
+    } else {
+        NSLog(@"Warning: There seem to be no columns in this set.");
+    }
+    
+    return nil;
+}
+
 
 
 


### PR DESCRIPTION
added a fixed property:   fat_resDictionary

take care of the condition :  join two tables, and they share some column names, in some cases, we may get Nsnull for these columns.

e.g. :
table A    colum1: 123,  colum2:234 , colum3:345

table B    colum2:234, colum3:null

select * from tableA left join table B on tableA.colum2 = tableB.colum2 

