### PR TITLE
Adds SQLCipher to the HEADER_SEARCH_PATHS of FMDB within the SQLCiphe…

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -43,8 +43,7 @@ Pod::Spec.new do |s|
     ss.dependency 'SQLCipher'
     ss.source_files = 'src/fmdb/FM*.{h,m}'
     ss.exclude_files = 'src/fmdb.m'
-    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }
-    ss.xcconfig = { 'HEADER_SEARCH_PATHS' => 'SQLCipher' }
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1', 'HEADER_SEARCH_PATHS' => 'SQLCipher' }
   end
   
 end

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
     ss.source_files = 'src/fmdb/FM*.{h,m}'
     ss.exclude_files = 'src/fmdb.m'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }
-    s.xcconfig = { 'HEADER_SEARCH_PATHS' => 'SQLCipher' }
+    ss.xcconfig = { 'HEADER_SEARCH_PATHS' => 'SQLCipher' }
   end
   
 end

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
     ss.source_files = 'src/fmdb/FM*.{h,m}'
     ss.exclude_files = 'src/fmdb.m'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1' }
+    s.xcconfig = { 'HEADER_SEARCH_PATHS' => 'SQLCipher' }
   end
   
 end


### PR DESCRIPTION
…r subspec.

When installing FMDB/SQLCipher via cocoa pods and using Swift, the proper SQLCipher copy of sqlite3.h isn't located so the sqlite3_key and sqlite3_rekey functions aren't found.  

This should hopefully resolve these issues:
https://github.com/ccgus/fmdb/issues/591
https://github.com/ccgus/fmdb/issues/618
https://github.com/ccgus/fmdb/issues/612

and accomplish the same thing as this PR (without changing the import statements/breaking direct integrations):
https://github.com/ccgus/fmdb/pull/594

A current workaround is to use a post_install hook in the Podfile:

```
post_install do |installer|
        installer.pods_project.targets.each do |target|
            if target.name == "FMDB"
               target.build_configurations.each do |config|
                   header_search = {"HEADER_SEARCH_PATHS" => "SQLCipher"}
                   config.build_settings.merge!(header_search)
               end
            end
        end
    end
```

