### PR TITLE
-[FMDatabase executeStatements:withResultBlock:] method crash

### DIFF
--- a/Tests/FMDatabaseTests.m
+++ b/Tests/FMDatabaseTests.m
@@ -1151,12 +1151,24 @@
         XCTAssertEqual(count, 1, @"expected one record for dictionary %@", dictionary);
         return 0;
     }];
+    
+    XCTAssertTrue(success, @"bulk select");
 
+    // select blob type records
+    [self.db executeUpdate:@"create table bulktest4 (id integer primary key autoincrement, b blob);"];
+    NSData *blobData = [[NSData alloc] initWithContentsOfFile:@"/bin/bash"];
+    [self.db executeUpdate:@"insert into bulktest4 (b) values (?)" values:@[blobData] error:nil];
+
+    sql = @"select * from bulktest4";
+    success = [self.db executeStatements:sql withResultBlock:^int(NSDictionary * _Nonnull resultsDictionary) {
+        return 0;
+    }];
     XCTAssertTrue(success, @"bulk select");
 
     sql = @"drop table bulktest1;"
            "drop table bulktest2;"
-           "drop table bulktest3;";
+           "drop table bulktest3;"
+           "drop table bulktest4";
 
     success = [self.db executeStatements:sql];
 

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1261,6 +1261,7 @@ int FMDBExecuteBulkSQLCallback(void *theBlockAsVoid, int columns, char **values,
     for (NSInteger i = 0; i < columns; i++) {
         NSString *key = [NSString stringWithUTF8String:names[i]];
         id value = values[i] ? [NSString stringWithUTF8String:values[i]] : [NSNull null];
+        value = value ? value : [NSNull null];
         [dictionary setObject:value forKey:key];
     }
     


### PR DESCRIPTION
`-[FMDatabase executeStatements:withResultBlock:]` method has potential crash bugs, for setting nil object as NSMutableDictionary value