### PR TITLE
Replace __attribute__((noescape)) with a macro to support compiling it with not supported compilers

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -521,7 +521,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
  */
 
-- (BOOL)executeStatements:(NSString *)sql withResultBlock:(__attribute__((noescape)) FMDBExecuteStatementsCallbackBlock _Nullable)block;
+- (BOOL)executeStatements:(NSString *)sql withResultBlock:(fmdb_noescape FMDBExecuteStatementsCallbackBlock _Nullable)block;
 
 /** Last insert rowid
  
@@ -1028,7 +1028,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  */
 
-- (NSError * _Nullable)inSavePoint:(__attribute__((noescape)) void (^)(BOOL *rollback))block;
+- (NSError * _Nullable)inSavePoint:(fmdb_noescape void (^)(BOOL *rollback))block;
 
 
 ///-----------------

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1277,7 +1277,7 @@ int FMDBExecuteBulkSQLCallback(void *theBlockAsVoid, int columns, char **values,
     return [self executeStatements:sql withResultBlock:nil];
 }
 
-- (BOOL)executeStatements:(NSString *)sql withResultBlock:(__attribute__((noescape)) FMDBExecuteStatementsCallbackBlock)block {
+- (BOOL)executeStatements:(NSString *)sql withResultBlock:(fmdb_noescape FMDBExecuteStatementsCallbackBlock)block {
     
     int rc;
     char *errmsg = nil;
@@ -1439,7 +1439,7 @@ static NSString *FMDBEscapeSavePointName(NSString *savepointName) {
 #endif
 }
 
-- (NSError*)inSavePoint:(__attribute__((noescape)) void (^)(BOOL *rollback))block {
+- (NSError*)inSavePoint:(fmdb_noescape void (^)(BOOL *rollback))block {
 #if SQLITE_VERSION_NUMBER >= 3007000
     static unsigned long savePointIdx = 0;
     

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -10,6 +10,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#ifndef fmdb_noescape
+    #if defined(__has_attribute) && __has_attribute(noescape)
+        #define fmdb_noescape __attribute__((noescape))
+    #else
+        #define fmdb_noescape
+    #endif // #if defined(__has_attribute) && __has_attribute(noescape)
+#endif // #ifndef fmdb_noescape
+
 @class FMDatabase;
 
 /** Pool of `<FMDatabase>` objects.
@@ -196,7 +204,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param block The code to be run on the `FMDatabasePool` pool.
  */
 
-- (void)inDatabase:(__attribute__((noescape)) void (^)(FMDatabase *db))block;
+- (void)inDatabase:(fmdb_noescape void (^)(FMDatabase *db))block;
 
 /** Synchronously perform database operations in pool using transaction.
  
@@ -211,28 +219,28 @@ NS_ASSUME_NONNULL_BEGIN
             to make your intent explicit, but also to future-proof your code.
   */
 
-- (void)inTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations in pool using exclusive transaction.
  
  @param block The code to be run on the `FMDatabasePool` pool.
  */
 
-- (void)inExclusiveTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inExclusiveTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations in pool using deferred transaction.
 
  @param block The code to be run on the `FMDatabasePool` pool.
  */
 
-- (void)inDeferredTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inDeferredTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using immediate transactions.
 
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-- (void)inImmediateTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inImmediateTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations in pool using save point.
 
@@ -243,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
  @warning You can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock. If you need to nest, use `<[FMDatabase startSavePointWithName:error:]>` instead.
 */
 
-- (NSError * _Nullable)inSavePoint:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (NSError * _Nullable)inSavePoint:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 @end
 

--- a/src/fmdb/FMDatabasePool.m
+++ b/src/fmdb/FMDatabasePool.m
@@ -241,7 +241,7 @@ typedef NS_ENUM(NSInteger, FMDBTransaction) {
     }];
 }
 
-- (void)inDatabase:(__attribute__((noescape)) void (^)(FMDatabase *db))block {
+- (void)inDatabase:(fmdb_noescape void (^)(FMDatabase *db))block {
     
     FMDatabase *db = [self db];
     
@@ -281,23 +281,23 @@ typedef NS_ENUM(NSInteger, FMDBTransaction) {
     [self pushDatabaseBackInPool:db];
 }
 
-- (void)inTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionExclusive withBlock:block];
 }
 
-- (void)inDeferredTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inDeferredTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionDeferred withBlock:block];
 }
 
-- (void)inExclusiveTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inExclusiveTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionExclusive withBlock:block];
 }
 
-- (void)inImmediateTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inImmediateTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionImmediate withBlock:block];
 }
 
-- (NSError*)inSavePoint:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (NSError*)inSavePoint:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
 #if SQLITE_VERSION_NUMBER >= 3007000
     static unsigned long savePointIdx = 0;
     

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-- (void)inDatabase:(__attribute__((noescape)) void (^)(FMDatabase *db))block;
+- (void)inDatabase:(fmdb_noescape void (^)(FMDatabase *db))block;
 
 /** Synchronously perform database operations on queue, using transactions.
 
@@ -216,28 +216,28 @@ NS_ASSUME_NONNULL_BEGIN
 
  */
 
-- (void)inTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using deferred transactions.
  
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-- (void)inDeferredTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inDeferredTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using exclusive transactions.
  
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-- (void)inExclusiveTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inExclusiveTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using immediate transactions.
 
  @param block The code to be run on the queue of `FMDatabaseQueue`
  */
 
-- (void)inImmediateTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (void)inImmediateTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 ///-----------------------------------------------
 /// @name Dispatching database operations to queue
@@ -250,7 +250,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // NOTE: you can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock.
 // If you need to nest, use FMDatabase's startSavePointWithName:error: instead.
-- (NSError * _Nullable)inSavePoint:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
+- (NSError * _Nullable)inSavePoint:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block;
 
 ///-----------------
 /// @name Checkpoint

--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -177,7 +177,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
     return _db;
 }
 
-- (void)inDatabase:(__attribute__((noescape)) void (^)(FMDatabase *db))block {
+- (void)inDatabase:(fmdb_noescape void (^)(FMDatabase *db))block {
 #ifndef NDEBUG
     /* Get the currently executing queue (which should probably be nil, but in theory could be another DB queue
      * and then check it against self to make sure we're not about to deadlock. */
@@ -240,23 +240,23 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
     FMDBRelease(self);
 }
 
-- (void)inTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionExclusive withBlock:block];
 }
 
-- (void)inDeferredTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inDeferredTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionDeferred withBlock:block];
 }
 
-- (void)inExclusiveTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (void)inExclusiveTransaction:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
     [self beginTransaction:FMDBTransactionExclusive withBlock:block];
 }
 
-- (void)inImmediateTransaction:(__attribute__((noescape)) void (^)(FMDatabase * _Nonnull, BOOL * _Nonnull))block {
+- (void)inImmediateTransaction:(fmdb_noescape void (^)(FMDatabase * _Nonnull, BOOL * _Nonnull))block {
     [self beginTransaction:FMDBTransactionImmediate withBlock:block];
 }
 
-- (NSError*)inSavePoint:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block {
+- (NSError*)inSavePoint:(fmdb_noescape void (^)(FMDatabase *db, BOOL *rollback))block {
 #if SQLITE_VERSION_NUMBER >= 3007000
     static unsigned long savePointIdx = 0;
     __block NSError *err = 0x00;


### PR DESCRIPTION
Hey! For linting / static analysis we are running a custom version of clang from llvm.org. Before clang 8, `__attribute__((noescape))` is not available and therefore if we are upgrading to the latest version of fmdb (or latest master) it will error out while compiling.

This pr is adding a macro to only add the attribute if the compiler supports it. We already did the same on `https://github.com/pinterest/PINRemoteImage` with `PIN_NOESCAPE`

I chose `fmdb_noescape` for the name, but I'm open to change it to whatever :)