### PR TITLE
Mark the setDateFormat method's parameter as _Nullable

### DIFF
--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -1341,7 +1341,7 @@ typedef NS_ENUM(int, SqliteValueType) {
  @warning Note there is no direct getter for the `NSDateFormatter`, and you should not use the formatter you pass to FMDB for other purposes, as `NSDateFormatter` is not thread-safe.
  */
 
-- (void)setDateFormat:(NSDateFormatter *)format;
+- (void)setDateFormat:(NSDateFormatter * _Nullable)format;
 
 /** Convert the supplied NSString to NSDate, using the current database formatter.
  
@@ -1371,7 +1371,7 @@ typedef NS_ENUM(int, SqliteValueType) {
  @see storeableDateFormat:
  */
 
-- (NSString *)stringFromDate:(NSDate *)date;
+- (NSString * _Nullable)stringFromDate:(NSDate *)date;
 
 @end
 


### PR DESCRIPTION
Passing in nil resets the FMDB to use a default unix date format. At the moment calling
this method with nil raises a warning in Xcode because it is marked as nonnull
because of the NS_ASSUME_NONNULL_BEGIN marcro.

This commit marks it correctly as _Nullable.