### PR TITLE
Add Bazel build rules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 fmdb.xcodeproj/*.mode1v3
 *.xcodeproj/project.xcworkspace/xcuserdata/
 fmdb.xcodeproj/project.xcworkspace
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,31 @@
+objc_library(
+    name = "fmdb",
+    srcs = glob(["src/fmdb/*.m"], exclude=["src/fmdb.m"]),
+    hdrs = glob(["src/fmdb/*.h"]),
+    includes = ["src"],
+    sdk_dylibs = ["sqlite3"],
+    visibility = ["//visibility:public"],
+)
+
+objc_library(
+    name = "fmdb_fts",
+    srcs = glob(["src/extra/fts3/*.m"]),
+    hdrs = glob(["src/extra/fts3/*.h"]),
+    deps = [":fmdb"],
+    visibility = ["//visibility:public"],
+)
+
+objc_library(
+    name = "fmdb_tests_lib",
+    srcs = glob(["Tests/*.h", "Tests/*.m"]),
+    deps = [":fmdb_fts"],
+    includes = ["src/fmdb", "src/extra/fts3"],
+    pch = "Tests/Tests-Prefix.pch",
+)
+
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_unit_test")
+macos_unit_test(
+    name = "fmdb_tests",
+    minimum_os_version = "10.11",
+    deps = [":fmdb_tests_lib"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,14 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    tag = "0.6.0",
+)
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()

--- a/src/extra/fts3/FMDatabase+FTS3.h
+++ b/src/extra/fts3/FMDatabase+FTS3.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Andrew Goodale. All rights reserved.
 //
 
-#import <FMDB/FMDatabase.h>
+#import <fmdb/FMDatabase.h>
 
 /**
  Names of commands that can be issued against an FTS table.


### PR DESCRIPTION
This allows other projects using Bazel (http://bazel.build) to easily import
FMDB by adding it to their WORKSPACE. 

I've included, from the CocoaPods spec, rules for core FMDB and the 
FTS extensions but not the rules that had extra dependencies. There are
also rules for running the unit tests from Bazel, in case that's useful.

I also made a capitalization change in FMDatabase+FTS3.h to silence a compiler warning.