### PR TITLE
Fix errmsg leaks

### DIFF
--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -1286,6 +1286,8 @@ int FMDBExecuteBulkSQLCallback(void *theBlockAsVoid, int columns, char **values,
     
     if (errmsg && [self logsErrors]) {
         NSLog(@"Error inserting batch: %s", errmsg);
+    }
+    if (errmsg) {
         sqlite3_free(errmsg);
     }
     


### PR DESCRIPTION
`
    if (errmsg && [self logsErrors]) {
        NSLog(@"Error inserting batch: %s", errmsg);
        sqlite3_free(errmsg);
    }
`

`errmsg` leaks here, if `logsErrors` is false.