### PR TITLE
fix issue #724 & #711

### DIFF
--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -195,6 +195,7 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
         
         if ([db hasOpenResultSets]) {
             NSLog(@"Warning: there is at least one open result set around after performing [FMDatabaseQueue inDatabase:]");
+            [db closeOpenResultSets];
             
 #if defined(DEBUG) && DEBUG
             NSSet *openSetCopy = FMDBReturnAutoreleased([[db valueForKey:@"_openResultSets"] copy]);


### PR DESCRIPTION
I write a demo to recurrent issue #724 & #711：

```objc
    NSString *dbPath = [docPath stringByAppendingPathComponent:@"test.sqlite"];
    _queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
    for (int i = 0; i < 10; i++) {
        dispatch_async(dispatch_get_global_queue(0, 0), ^{
            [_queue inDatabase:^(FMDatabase * _Nonnull db) {
                FMResultSet *result = [db executeQuery:@"select * from test1 where a = '1'"];
                if ([result next]) {
                }
                // do not close FMResultSet
//                [result close];
            }];
        });
    }
```

I think the crash reason was if user traversed FMResultSet used `if ([result close])` not `while ([result close])`. 
FMResultSet `dealloc` in `AutoreleasePoolPage::pop()`, then `[FMResultSet close]` will be called, if user  reading and writing to the database currently, the database was accessed by multi-threaded.
I suggest to modify this like this, if the user did not close the FMResultSet after the block ends, we close it in current dispatch_queue_t.