### PR TITLE
Adds SQLCipher subspec major version cap which will prevent `pod upda…

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
 
   # use SQLCipher and enable -DSQLITE_HAS_CODEC flag
   s.subspec 'SQLCipher' do |ss|
-    ss.dependency 'SQLCipher'
+    ss.dependency 'SQLCipher', '~> 4.0'
     ss.source_files = 'src/fmdb/FM*.{h,m}'
     ss.exclude_files = 'src/fmdb.m'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1', 'HEADER_SEARCH_PATHS' => 'SQLCipher' }


### PR DESCRIPTION
…te` from updating beyond the current major version until explicitly changed in pod subspec.

Related to: https://github.com/ccgus/fmdb/issues/736

This will maintain a dependency version for SQLCipher subspec so that it won't automatically move to the next major version (if one exists) on folks when they run `pod update`.  This will need to be manually adjusted when we want to bump to the next major version of SQLCipher (i.e. `ss.dependency 'SQLCipher', '~> 5.0'`)