### PR TITLE
Allow rebinding

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -3,8 +3,11 @@ Zip, nada, zilch.  Got any ideas?
 
 If you would like to contribute some code ... awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add the necessary of tests for your new code to tests target.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
 
+2020.05.06 Version 2.7.7
+    Add `prepare` and `bind` methods so you can prepare a statement once and bind values repeatedly.
+
 2020.04.23 Version 2.7.6
-A new tag for the Swift Package Manager.
+    A new tag for the Swift Package Manager.
 
 2018.10.23 Version 2.7.5
     Xcode 10 support. Probably some other stuff over the past year as well.

--- a/README.markdown
+++ b/README.markdown
@@ -3,15 +3,15 @@
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/FMDB.svg)](https://img.shields.io/cocoapods/v/FMDB.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-This is an Objective-C wrapper around SQLite: http://sqlite.org/
+This is an Objective-C wrapper around [SQLite](https://sqlite.org/).
 
 ## The FMDB Mailing List:
-http://groups.google.com/group/fmdb
+https://groups.google.com/group/fmdb
 
 ## Read the SQLite FAQ:
-http://www.sqlite.org/faq.html
+https://www.sqlite.org/faq.html
 
-Since FMDB is built on top of SQLite, you're going to want to read this page top to bottom at least once.  And while you're there, make sure to bookmark the SQLite Documentation page: http://www.sqlite.org/docs.html
+Since FMDB is built on top of SQLite, you're going to want to read this page top to bottom at least once.  And while you're there, make sure to bookmark the SQLite Documentation page: https://www.sqlite.org/docs.html
 
 ## Contributing
 Do you have an awesome idea that deserves to be in FMDB?  You might consider pinging ccgus first to make sure he hasn't already ruled it out for some reason.  Otherwise pull requests are great, and make sure you stick to the local coding conventions.  However, please be patient and if you haven't heard anything from ccgus for a week or more, you might want to send a note asking what's up.
@@ -19,9 +19,6 @@ Do you have an awesome idea that deserves to be in FMDB?  You might consider pin
 ## Installing
 
 ### CocoaPods
-
-[![Dependency Status](https://www.versioneye.com/objective-c/fmdb/2.3/badge.svg?style=flat)](https://www.versioneye.com/objective-c/fmdb/2.3)
-[![Reference Status](https://www.versioneye.com/objective-c/fmdb/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/fmdb/references)
 
 FMDB can be installed using [CocoaPods](https://cocoapods.org/).
 
@@ -75,7 +72,7 @@ $ carthage update
 You can then configure your project as outlined in Carthage's [Getting Started](https://github.com/Carthage/Carthage#getting-started) (i.e. for iOS, adding the framework to the "Link Binary with Libraries" in your target and adding the `copy-frameworks` script; in macOS, adding the framework to the list of "Embedded Binaries").
 
 ## FMDB Class Reference:
-http://ccgus.github.io/fmdb/html/index.html
+https://ccgus.github.io/fmdb/html/index.html
 
 ## Automatic Reference Counting (ARC) or Manual Memory Management?
 You can use either style in your Cocoa project.  FMDB will figure out which you are using at compile time and do the right thing.
@@ -182,7 +179,7 @@ An `FMDatabase` is created with a path to a SQLite database file.  This path can
 2. An empty string (`@""`).  An empty database is created at a temporary location.  This database is deleted when the `FMDatabase` connection is closed.
 3. `NULL`.  An in-memory database is created.  This database will be destroyed when the `FMDatabase` connection is closed.
 
-(For more information on temporary and in-memory databases, read the sqlite documentation on the subject: http://www.sqlite.org/inmemorydb.html)
+(For more information on temporary and in-memory databases, read the sqlite documentation on the subject: https://www.sqlite.org/inmemorydb.html)
 
 ```objc
 NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"tmp.db"];
@@ -436,7 +433,7 @@ To do this, you must:
 
 1. Copy the relevant `.m` and `.h` files from the FMDB `src` folder into your project.
 
- You can copy all of them (which is easiest), or only the ones you need. Likely you will need [`FMDatabase`](http://ccgus.github.io/fmdb/html/Classes/FMDatabase.html) and [`FMResultSet`](http://ccgus.github.io/fmdb/html/Classes/FMResultSet.html) at a minimum. [`FMDatabaseAdditions`](http://ccgus.github.io/fmdb/html/Categories/FMDatabase+FMDatabaseAdditions.html) provides some very useful convenience methods, so you will likely want that, too. If you are doing multithreaded access to a database, [`FMDatabaseQueue`](http://ccgus.github.io/fmdb/html/Classes/FMDatabaseQueue.html) is quite useful, too. If you choose to not copy all of the files from the `src` directory, though, you may want to update `FMDB.h` to only reference the files that you included in your project.
+ You can copy all of them (which is easiest), or only the ones you need. Likely you will need [`FMDatabase`](https://ccgus.github.io/fmdb/html/Classes/FMDatabase.html) and [`FMResultSet`](https://ccgus.github.io/fmdb/html/Classes/FMResultSet.html) at a minimum. [`FMDatabaseAdditions`](https://ccgus.github.io/fmdb/html/Categories/FMDatabase+FMDatabaseAdditions.html) provides some very useful convenience methods, so you will likely want that, too. If you are doing multithreaded access to a database, [`FMDatabaseQueue`](https://ccgus.github.io/fmdb/html/Classes/FMDatabaseQueue.html) is quite useful, too. If you choose to not copy all of the files from the `src` directory, though, you may want to update `FMDB.h` to only reference the files that you included in your project.
 
  Note, if you're copying all of the files from the `src` folder into to your project (which is recommended), you may want to drag the individual files into your project, not the folder, itself, because if you drag the folder, you won't be prompted to add the bridging header (see next point).
 

--- a/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.h
+++ b/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.h
@@ -12,7 +12,7 @@
 //  support for this functionality via its "Backup" API.  Here, we extend the FMBD wrapper
 //  to include this functionality.
 //
-//  http://www.sqlite.org/backup.html
+//  https://sqlite.org/backup.html
 
 #import "FMDatabase.h"
 

--- a/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
+++ b/src/extra/InMemoryOnDiskIO/FMDatabase+InMemoryOnDiskIO.m
@@ -2,7 +2,7 @@
 #import <sqlite3.h>
 
 
-// http://www.sqlite.org/backup.html
+// https://sqlite.org/backup.html
 static
 int loadOrSaveDb(sqlite3 *pInMemory, const char *zFilename, int isSave)
 {

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
     FMDBCheckpointModeTruncate = 3  // SQLITE_CHECKPOINT_TRUNCATE
 };
 
-/** A SQLite ([http://sqlite.org/](http://sqlite.org/)) Objective-C wrapper.
+/** A SQLite ([https://sqlite.org/](https://sqlite.org/)) Objective-C wrapper.
  
  ### Usage
  The three main classes in FMDB are:
@@ -65,9 +65,9 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  ### External links
  
  - [FMDB on GitHub](https://github.com/ccgus/fmdb) including introductory documentation
- - [SQLite web site](http://sqlite.org/)
+ - [SQLite web site](https://sqlite.org/)
  - [FMDB mailing list](http://groups.google.com/group/fmdb)
- - [SQLite FAQ](http://www.sqlite.org/faq.html)
+ - [SQLite FAQ](https://sqlite.org/faq.html)
  
  @warning Do not instantiate a single `FMDatabase` object and use it across multiple threads. Instead, use `<FMDatabaseQueue>`.
 
@@ -125,7 +125,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
     NSString *dbPath   = [docsPath stringByAppendingPathComponent:@"test.db"];
     FMDatabase *db     = [FMDatabase databaseWithPath:dbPath];
 
- (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [http://www.sqlite.org/inmemorydb.html](http://www.sqlite.org/inmemorydb.html))
+ (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [https://sqlite.org/inmemorydb.html](https://sqlite.org/inmemorydb.html))
 
  @param inPath Path of database file
 
@@ -152,7 +152,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
     NSString *dbPath   = [docsPath stringByAppendingPathComponent:@"test.db"];
     FMDatabase *db     = [FMDatabase databaseWithPath:dbPath];
  
- (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [http://www.sqlite.org/inmemorydb.html](http://www.sqlite.org/inmemorydb.html))
+ (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [https://sqlite.org/inmemorydb.html](https://sqlite.org/inmemorydb.html))
  
  @param url The local file URL (not remote URL) of database file
  
@@ -180,7 +180,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
     NSString *dbPath   = [docsPath stringByAppendingPathComponent:@"test.db"];
     FMDatabase *db     = [FMDatabase databaseWithPath:dbPath];
 
- (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [http://www.sqlite.org/inmemorydb.html](http://www.sqlite.org/inmemorydb.html))
+ (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [https://sqlite.org/inmemorydb.html](https://sqlite.org/inmemorydb.html))
 
  @param path Path of database file.
  
@@ -207,7 +207,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  NSString *dbPath   = [docsPath stringByAppendingPathComponent:@"test.db"];
  FMDatabase *db     = [FMDatabase databaseWithPath:dbPath];
  
- (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [http://www.sqlite.org/inmemorydb.html](http://www.sqlite.org/inmemorydb.html))
+ (For more information on temporary and in-memory databases, read the sqlite documentation on the subject: [https://sqlite.org/inmemorydb.html](https://sqlite.org/inmemorydb.html))
  
  @param url The file `NSURL` of database file.
  
@@ -231,7 +231,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
  @return `YES` if successful, `NO` on error.
 
- @see [sqlite3_open()](http://sqlite.org/c3ref/open.html)
+ @see [sqlite3_open()](https://sqlite.org/c3ref/open.html)
  @see openWithFlags:
  @see close
  */
@@ -256,7 +256,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
   
  @return `YES` if successful, `NO` on error.
 
- @see [sqlite3_open_v2()](http://sqlite.org/c3ref/open.html)
+ @see [sqlite3_open_v2()](https://sqlite.org/c3ref/open.html)
  @see open
  @see close
  */
@@ -283,7 +283,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @return `YES` if successful, `NO` on error.
  
- @see [sqlite3_open_v2()](http://sqlite.org/c3ref/open.html)
+ @see [sqlite3_open_v2()](https://sqlite.org/c3ref/open.html)
  @see open
  @see close
  */
@@ -294,7 +294,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @return `YES` if success, `NO` on error.
  
- @see [sqlite3_close()](http://sqlite.org/c3ref/close.html)
+ @see [sqlite3_close()](https://sqlite.org/c3ref/close.html)
  @see open
  @see openWithFlags:
  */
@@ -320,7 +320,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
  
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html), [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html) to bind values to `?` placeholders in the SQL with the optional list of parameters, and [`sqlite_step`](http://sqlite.org/c3ref/step.html) to perform the update.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html), [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html) to bind values to `?` placeholders in the SQL with the optional list of parameters, and [`sqlite_step`](https://sqlite.org/c3ref/step.html) to perform the update.
 
  The optional values provided to this method should be objects (e.g. `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects), not fundamental data types (e.g. `int`, `long`, `NSInteger`, etc.). This method automatically handles the aforementioned object types, and all other object types will be interpreted as text values using the object's `description` method.
 
@@ -335,7 +335,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  @see lastError
  @see lastErrorCode
  @see lastErrorMessage
- @see [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html)
+ @see [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html)
  */
 
 - (BOOL)executeUpdate:(NSString*)sql withErrorAndBindings:(NSError * _Nullable __autoreleasing *)outErr, ...;
@@ -351,7 +351,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
 
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html), [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html) to bind values to `?` placeholders in the SQL with the optional list of parameters, and [`sqlite_step`](http://sqlite.org/c3ref/step.html) to perform the update.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html), [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html) to bind values to `?` placeholders in the SQL with the optional list of parameters, and [`sqlite_step`](https://sqlite.org/c3ref/step.html) to perform the update.
 
  The optional values provided to this method should be objects (e.g. `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects), not fundamental data types (e.g. `int`, `long`, `NSInteger`, etc.). This method automatically handles the aforementioned object types, and all other object types will be interpreted as text values using the object's `description` method.
  
@@ -364,7 +364,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  @see lastError
  @see lastErrorCode
  @see lastErrorMessage
- @see [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html)
+ @see [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html)
  
  @note This technique supports the use of `?` placeholders in the SQL, automatically binding any supplied value parameters to those placeholders. This approach is more robust than techniques that entail using `stringWithFormat` to manually build SQL statements, which can be problematic if the values happened to include any characters that needed to be quoted.
  
@@ -375,7 +375,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
 
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html) and [`sqlite_step`](http://sqlite.org/c3ref/step.html) to perform the update. Unlike the other `executeUpdate` methods, this uses printf-style formatters (e.g. `%s`, `%d`, etc.) to build the SQL. Do not use `?` placeholders in the SQL if you use this method.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html) and [`sqlite_step`](https://sqlite.org/c3ref/step.html) to perform the update. Unlike the other `executeUpdate` methods, this uses printf-style formatters (e.g. `%s`, `%d`, etc.) to build the SQL. Do not use `?` placeholders in the SQL if you use this method.
 
  @param format The SQL to be performed, with `printf`-style escape sequences.
 
@@ -403,7 +403,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
  
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html) and [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html) binding any `?` placeholders in the SQL with the optional list of parameters.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html) and [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html) binding any `?` placeholders in the SQL with the optional list of parameters.
  
  The optional values provided to this method should be objects (e.g. `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects), not fundamental data types (e.g. `int`, `long`, `NSInteger`, etc.). This method automatically handles the aforementioned object types, and all other object types will be interpreted as text values using the object's `description` method.
  
@@ -423,7 +423,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
  
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html) and [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html) binding any `?` placeholders in the SQL with the optional list of parameters.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html) and [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html) binding any `?` placeholders in the SQL with the optional list of parameters.
  
  The optional values provided to this method should be objects (e.g. `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects), not fundamental data types (e.g. `int`, `long`, `NSInteger`, etc.). This method automatically handles the aforementioned object types, and all other object types will be interpreted as text values using the object's `description` method.
  
@@ -451,7 +451,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
 
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html) and [`sqlite_step`](http://sqlite.org/c3ref/step.html) to perform the update. Unlike the other `executeUpdate` methods, this uses printf-style formatters (e.g. `%s`, `%d`, etc.) to build the SQL.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html) and [`sqlite_step`](https://sqlite.org/c3ref/step.html) to perform the update. Unlike the other `executeUpdate` methods, this uses printf-style formatters (e.g. `%s`, `%d`, etc.) to build the SQL.
 
  The optional values provided to this method should be objects (e.g. `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects), not fundamental data types (e.g. `int`, `long`, `NSInteger`, etc.). This method automatically handles the aforementioned object types, and all other object types will be interpreted as text values using the object's `description` method.
 
@@ -471,7 +471,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
 /** Execute single update statement
 
- This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](http://sqlite.org/c3ref/prepare.html) and [`sqlite_step`](http://sqlite.org/c3ref/step.html) to perform the update. Unlike the other `executeUpdate` methods, this uses printf-style formatters (e.g. `%s`, `%d`, etc.) to build the SQL.
+ This method executes a single SQL update statement (i.e. any SQL that does not return results, such as `UPDATE`, `INSERT`, or `DELETE`. This method employs [`sqlite3_prepare_v2`](https://sqlite.org/c3ref/prepare.html) and [`sqlite_step`](https://sqlite.org/c3ref/step.html) to perform the update. Unlike the other `executeUpdate` methods, this uses printf-style formatters (e.g. `%s`, `%d`, etc.) to build the SQL.
 
  The optional values provided to this method should be objects (e.g. `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects), not fundamental data types (e.g. `int`, `long`, `NSInteger`, etc.). This method automatically handles the aforementioned object types, and all other object types will be interpreted as text values using the object's `description` method.
 
@@ -497,7 +497,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  @return      `YES` upon success; `NO` upon failure. If failed, you can call `<lastError>`, `<lastErrorCode>`, or `<lastErrorMessage>` for diagnostic information regarding the failure.
 
  @see executeStatements:withResultBlock:
- @see [sqlite3_exec()](http://sqlite.org/c3ref/exec.html)
+ @see [sqlite3_exec()](https://sqlite.org/c3ref/exec.html)
 
  */
 
@@ -517,7 +517,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
                   `<lastErrorCode>`, or `<lastErrorMessage>` for diagnostic information regarding the failure.
  
  @see executeStatements:
- @see [sqlite3_exec()](http://sqlite.org/c3ref/exec.html)
+ @see [sqlite3_exec()](https://sqlite.org/c3ref/exec.html)
 
  */
 
@@ -531,7 +531,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @return The rowid of the last inserted row.
  
- @see [sqlite3_last_insert_rowid()](http://sqlite.org/c3ref/last_insert_rowid.html)
+ @see [sqlite3_last_insert_rowid()](https://sqlite.org/c3ref/last_insert_rowid.html)
 
  */
 
@@ -543,7 +543,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @return The number of rows changed by prior SQL statement.
  
- @see [sqlite3_changes()](http://sqlite.org/c3ref/changes.html)
+ @see [sqlite3_changes()](https://sqlite.org/c3ref/changes.html)
  
  */
 
@@ -560,7 +560,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  In order to iterate through the results of your query, you use a `while()` loop.  You also need to "step" (via `<[FMResultSet next]>`) from one record to the other.
  
- This method employs [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html) for any optional value parameters. This  properly escapes any characters that need escape sequences (e.g. quotation marks), which eliminates simple SQL errors as well as protects against SQL injection attacks. This method natively handles `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects. All other object types will be interpreted as text values using the object's `description` method.
+ This method employs [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html) for any optional value parameters. This  properly escapes any characters that need escape sequences (e.g. quotation marks), which eliminates simple SQL errors as well as protects against SQL injection attacks. This method natively handles `NSString`, `NSNumber`, `NSNull`, `NSDate`, and `NSData` objects. All other object types will be interpreted as text values using the object's `description` method.
 
  @param sql The SELECT statement to be performed, with optional `?` placeholders.
 
@@ -570,7 +570,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @see FMResultSet
  @see [`FMResultSet next`](<[FMResultSet next]>)
- @see [`sqlite3_bind`](http://sqlite.org/c3ref/bind_blob.html)
+ @see [`sqlite3_bind`](https://sqlite.org/c3ref/bind_blob.html)
  
  @note You cannot use this method from Swift due to incompatibilities between Swift and Objective-C variadic implementations. Consider using `<executeQuery:values:>` instead.
  */
@@ -903,7 +903,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
  @return `NSString` of the last error message.
  
- @see [sqlite3_errmsg()](http://sqlite.org/c3ref/errcode.html)
+ @see [sqlite3_errmsg()](https://sqlite.org/c3ref/errcode.html)
  @see lastErrorCode
  @see lastError
  
@@ -917,7 +917,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @return Integer value of the last error code.
  
- @see [sqlite3_errcode()](http://sqlite.org/c3ref/errcode.html)
+ @see [sqlite3_errcode()](https://sqlite.org/c3ref/errcode.html)
  @see lastErrorMessage
  @see lastError
  
@@ -931,9 +931,9 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
  
  @return Integer value of the last extended error code.
  
- @see [sqlite3_errcode()](http://sqlite.org/c3ref/errcode.html)
- @see [2. Primary Result Codes versus Extended Result Codes](http://sqlite.org/rescode.html#primary_result_codes_versus_extended_result_codes)
- @see [5. Extended Result Code List](http://sqlite.org/rescode.html#extrc)
+ @see [sqlite3_errcode()](https://sqlite.org/c3ref/errcode.html)
+ @see [2. Primary Result Codes versus Extended Result Codes](https://sqlite.org/rescode.html#primary_result_codes_versus_extended_result_codes)
+ @see [5. Extended Result Code List](https://sqlite.org/rescode.html#extrc)
  @see lastErrorMessage
  @see lastError
  
@@ -1071,16 +1071,28 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
  @return `NO` if and only if SQLite was compiled with mutexing code omitted due to the SQLITE_THREADSAFE compile-time option being set to 0.
 
- @see [sqlite3_threadsafe()](http://sqlite.org/c3ref/threadsafe.html)
+ @see [sqlite3_threadsafe()](https://sqlite.org/c3ref/threadsafe.html)
  */
 
 + (BOOL)isSQLiteThreadSafe;
+
+/** Examine/set limits
+
+ @param type The type of limit. See https://sqlite.org/c3ref/c_limit_attached.html
+ @param newLimit The new limit value. Use -1 if you don't want to change the limit, but rather only want to check it.
+
+ @return Regardless, returns previous value.
+
+ @see [sqlite3_limit()](https://sqlite.org/c3ref/limit.html)
+*/
+
+- (int)limitFor:(int)type value:(int)newLimit;
 
 /** Run-time library version numbers
  
  @return The sqlite library version string.
  
- @see [sqlite3_libversion()](http://sqlite.org/c3ref/libversion.html)
+ @see [sqlite3_libversion()](https://sqlite.org/c3ref/libversion.html)
  */
 
 + (NSString*)sqliteLibVersion;
@@ -1149,7 +1161,7 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 
  @param block The block of code for the function.
 
- @see [sqlite3_create_function()](http://sqlite.org/c3ref/create_function.html)
+ @see [sqlite3_create_function()](https://sqlite.org/c3ref/create_function.html)
  */
 
 - (void)makeFunctionNamed:(NSString *)name arguments:(int)arguments block:(void (^)(void *context, int argc, void * _Nonnull * _Nonnull argv))block;
@@ -1410,7 +1422,7 @@ typedef NS_ENUM(int, SqliteValueType) {
  
  - `<FMDatabase>`
  - `<FMResultSet>`
- - [`sqlite3_stmt`](http://www.sqlite.org/c3ref/stmt.html)
+ - [`sqlite3_stmt`](https://sqlite.org/c3ref/stmt.html)
  */
 
 @interface FMStatement : NSObject {
@@ -1434,7 +1446,7 @@ typedef NS_ENUM(int, SqliteValueType) {
 
 /** SQLite sqlite3_stmt
  
- @see [`sqlite3_stmt`](http://www.sqlite.org/c3ref/stmt.html)
+ @see [`sqlite3_stmt`](https://sqlite.org/c3ref/stmt.html)
  */
 
 @property (atomic, assign) void *statement;

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -677,6 +677,12 @@ typedef NS_ENUM(int, FMDBCheckpointMode) {
 // Documentation forthcoming.
 - (FMResultSet * _Nullable)executeQuery:(NSString *)sql withVAList:(va_list)args;
 
+/// Prepare SQL statement.
+///
+/// @param sql SQL statement to prepare, generally with `?` placeholders.
+
+- (FMResultSet *)prepare:(NSString *)sql;
+
 ///-------------------
 /// @name Transactions
 ///-------------------

--- a/src/fmdb/FMDatabaseAdditions.h
+++ b/src/fmdb/FMDatabaseAdditions.h
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return `FMResultSet` of schema; `nil` on error.
  
- @see [SQLite File Format](http://www.sqlite.org/fileformat.html)
+ @see [SQLite File Format](https://sqlite.org/fileformat.html)
  */
 
 - (FMResultSet * _Nullable)getSchema;
@@ -163,7 +163,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return `FMResultSet` of schema; `nil` on error.
  
- @see [table_info](http://www.sqlite.org/pragma.html#pragma_table_info)
+ @see [table_info](https://sqlite.org/pragma.html#pragma_table_info)
  */
 
 - (FMResultSet * _Nullable)getTableSchema:(NSString*)tableName;

--- a/src/fmdb/FMDatabaseAdditions.m
+++ b/src/fmdb/FMDatabaseAdditions.m
@@ -17,7 +17,7 @@
 #endif
 
 @interface FMDatabase (PrivateStuff)
-- (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray * _Nullable)arrayArgs orDictionary:(NSDictionary * _Nullable)dictionaryArgs orVAList:(va_list)args;
+- (FMResultSet * _Nullable)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray * _Nullable)arrayArgs orDictionary:(NSDictionary * _Nullable)dictionaryArgs orVAList:(va_list)args shouldBind:(BOOL)shouldBind;
 @end
 
 @implementation FMDatabase (FMDatabaseAdditions)
@@ -25,7 +25,7 @@
 #define RETURN_RESULT_FOR_QUERY_WITH_SELECTOR(type, sel)             \
 va_list args;                                                        \
 va_start(args, query);                                               \
-FMResultSet *resultSet = [self executeQuery:query withArgumentsInArray:0x00 orDictionary:0x00 orVAList:args];   \
+FMResultSet *resultSet = [self executeQuery:query withArgumentsInArray:0x00 orDictionary:0x00 orVAList:args shouldBind:true];   \
 va_end(args);                                                        \
 if (![resultSet next]) { return (type)0; }                           \
 type ret = [resultSet sel:0];                                        \

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A `FMResultSet` on success; `nil` on failure
  */
 
-+ (instancetype)resultSetWithStatement:(FMStatement *)statement usingParentDatabase:(FMDatabase*)aDB;
++ (instancetype)resultSetWithStatement:(FMStatement *)statement usingParentDatabase:(FMDatabase*)aDB shouldAutoClose:(BOOL)shouldAutoClose;
 
 /** Close result set */
 
@@ -91,10 +91,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)nextWithError:(NSError * _Nullable __autoreleasing *)outErr;
 
+/** Perform SQL statement.
+
+ @return 'YES' if successful; 'NO' if not.
+
+ @see hasAnotherRow
+*/
+
+- (BOOL)step;
+
+/** Perform SQL statement.
+
+ @param outErr A 'NSError' object to receive any error object (if any).
+
+ @return 'YES' if successful; 'NO' if not.
+
+ @see hasAnotherRow
+*/
+
+- (BOOL)stepWithError:(NSError * _Nullable __autoreleasing *)outErr;
+
 /** Did the last call to `<next>` succeed in retrieving another row?
 
- @return `YES` if the last call to `<next>` succeeded in retrieving another record; `NO` if not.
- 
+ @return 'YES' if there is another row; 'NO' if not.
+
  @see next
  
  @warning The `hasAnotherRow` method must follow a call to `<next>`. If the previous database interaction was something other than a call to `next`, then this method may return `NO`, whether there is another row of data or not.
@@ -461,7 +481,22 @@ If you don't, you're going to be in a world of hurt when you try and use the dat
 
 - (void)kvcMagic:(id)object;
 
- 
+///-----------------------------
+/// @name Binding values
+///-----------------------------
+
+/// Bind array of values to prepared statement.
+///
+/// @param array Array of values to bind to SQL statement.
+
+- (BOOL)bindWithArray:(NSArray*)array;
+
+/// Bind dictionary of values to prepared statement.
+///
+/// @param dictionary Dictionary of values to bind to SQL statement.
+
+- (BOOL)bindWithDictionary:(NSDictionary *)dictionary;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
* Allow re-binding of SQLite statements

  - Reduced `executeUpdate` to call `executeQuery` and remove redundant code;
  - Abstracted binding code out of from `executeQuery`;
  - Created “prepare” method on `FMDatabase` (that prepares statement but doesn’t bind anything);
  - Created “bind” methods on `FMResultSet` to bind values; and
  - Created unit tests for both array and dictionary parameter types; each tests both update queries and select queries.

Usage:

For execute queries:

```
FMResultSet *rs = [db prepare:@"INSERT INTO foo (bar) VALUES (?)"];
if ([rs bindWithArray:@[value1]]) {
     if ([rs step]) {
         // successful
     }
}

if ([rs bindWithArray:@[value2]]) {
    if ([rs step]) {
        // successful
    }
}
```

While it’s most useful for `INSERT` and `UPDATE` queries, you can theoretically use it for select queries, too:

```
rs = [db prepare:@"SELECT bar FROM foo WHERE bar = ?"];
if ([rs bindWithArray:@[value1]]) {
    while ([rs next]) {
        NSString *value = [rs stringForColumnIndex:0];
    }
}

if ([rs bindWithArray:@[value2]]) {
    while ([rs next]) {
        NSString *value = [rs stringForColumnIndex:0];
    }
}
```

* Detect and handle `sqlite3_bind` errors;

  - Create unit test that manifests bind errors (by trying to insert `NSData` that is too big); it checks this limit and tries to insert something too big;
  - Created `limitFor:value:` to call `sqlite3_limit` so I could create aforementioned test that would reliably fail; and
  - Modified bind routines to return result of `sqlite3_bind_xxx` failures.

* While looking at binding code, I noticed that it was using `SQLITE_STATIC`. That’s a little dangerous depending upon the calling point:

  - Create unit test that manifests when using `SQLITE_STATIC` (it’s a contrived example, but illustrates the problem); and
  - Changed binding routines to use `SQLITE_TRANSIENT` not `SQLITE_STATIC`.

* In a separate commit, I replaced all the http references to sqlite.org with https reference, as the links no longer work without https.