### PR TITLE
Uninitialized object in manual reference counting

### DIFF
--- a/src/fmdb/FMDatabaseQueue.m
+++ b/src/fmdb/FMDatabaseQueue.m
@@ -301,17 +301,13 @@ static const void * const kDispatchQueueSpecificKey = &kDispatchQueueSpecificKey
 - (BOOL)checkpoint:(FMDBCheckpointMode)mode name:(NSString *)name logFrameCount:(int * _Nullable)logFrameCount checkpointCount:(int * _Nullable)checkpointCount error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
     __block BOOL result;
-    __block NSError *blockError;
-    
+
     FMDBRetain(self);
     dispatch_sync(_queue, ^() {
-        result = [self.database checkpoint:mode name:name logFrameCount:logFrameCount checkpointCount:checkpointCount error:&blockError];
+        result = [self.database checkpoint:mode name:name logFrameCount:logFrameCount checkpointCount:checkpointCount error:error];
     });
     FMDBRelease(self);
     
-    if (error) {
-        *error = blockError;
-    }
     return result;
 }
 


### PR DESCRIPTION
I can’t imagine that anyone is using manual referencing counting any more, but there was an uninitialized pointer. 

<img width="957" alt="Screen Shot 2020-05-07 at 6 59 28 PM" src="https://user-images.githubusercontent.com/1530768/81363694-cef7da80-9098-11ea-9ad3-387515b20eb2.png">

Turns out that `blockError` reference is not needed, anyway, so let’s cut the Gordian knot.