### PR TITLE
Update header comments & documentation

### DIFF
--- a/src/extra/fts3/FMDatabase+FTS3.h
+++ b/src/extra/fts3/FMDatabase+FTS3.h
@@ -36,12 +36,12 @@ extern NSString *const kFTSCommandAutoMerge;       // "automerge=%u"
 + (void)registerTokenizer:(id<FMTokenizerDelegate>)tokenizer withKey:(NSString *)key;
 
 /**
- Calls the `fts3_tokenizer()` function on this database, installing tokenizer module with the 'fmdb' name.
+ Calls the @c fts3_tokenizer function on this database, installing tokenizer module with the 'fmdb' name.
  */
 - (BOOL)installTokenizerModule;
 
 /**
- Calls the `fts3_tokenizer()` function on this database, installing the tokenizer module with specified name.
+ Calls the @c fts3_tokenizer function on this database, installing the tokenizer module with specified name.
  */
 - (BOOL)installTokenizerModuleWithName:(NSString *)name;
 
@@ -89,8 +89,8 @@ typedef struct FMTokenizerCursor
 
 /**
  Enumerate each set of offsets in the result. The column number can be turned into a column name
- using `[FMResultSet columnNameForIndex:]`. The `matchRange` is in UTF-8 byte positions, so it must be 
- modified to use with `NSString` data.
+ using `[FMResultSet columnNameForIndex:]`. The @c matchRange is in UTF-8 byte positions, so it must be 
+ modified to use with @c NSString  data.
  */
 - (void)enumerateWithBlock:(void (^)(NSInteger columnNumber, NSInteger termNumber, NSRange matchRange))block;
 
@@ -102,12 +102,12 @@ typedef struct FMTokenizerCursor
 @interface FMResultSet (FTS3)
 
 /**
- Returns a structure containing values from the `offsets()` function. Make sure the column index corresponds
+ Returns a structure containing values from the @c offsets function. Make sure the column index corresponds
  to the column index in the SQL query.
  
  @param columnIdx Zero-based index for column.
  
- @return `FMTextOffsets` structure.
+ @return @c FMTextOffsets structure.
  */
 - (FMTextOffsets *)offsetsForColumnIndex:(int)columnIdx;
 

--- a/src/extra/fts3/FMTokenizers.h
+++ b/src/extra/fts3/FMTokenizers.h
@@ -18,7 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Create the tokenizer with a given locale. The locale will be used to initialize the string tokenizer and to lowercase the parsed word.
- The locale can be `NULL`, in which case the current locale will be used.
+
+
+ @param locale The locale used by the simple tokenizer. The locale can be @c NULL , in which case the current locale will be used.
  */
 - (instancetype)initWithLocale:(CFLocaleRef _Nullable)locale;
 
@@ -35,12 +37,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Load a stop-word tokenizer using a file containing words delimited by newlines. The file should be encoded in UTF-8.
+
+ @param wordFileURL The file URL for the list of words.
+ @param tokenizer The @c FMTokenizerDelegate .
+ @param error The @c NSError if there was any error reading the file.
  */
 + (instancetype)tokenizerWithFileURL:(NSURL *)wordFileURL baseTokenizer:(id<FMTokenizerDelegate>)tokenizer error:(NSError * _Nullable *)error;
 
 /**
- Initialize an instance of the tokenizer using the set of words. The words should be lowercase if you're using the 
+ Initialize an instance of the tokenizer using the set of words. The words should be lowercase if you're using the
  `FMSimpleTokenizer` as the base.
+ @param words The @c NSSet of words.
+ @param tokenizer The @c FMTokenizerDelegate .
  */
 - (instancetype)initWithWords:(NSSet *)words baseTokenizer:(id<FMTokenizerDelegate>)tokenizer;
 

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FMResultSet ()
 
 - (int)internalStepWithError:(NSError * _Nullable __autoreleasing *)outErr;
++ (instancetype)resultSetWithStatement:(FMStatement *)statement usingParentDatabase:(FMDatabase*)aDB shouldAutoClose:(BOOL)shouldAutoClose;
 
 @end
 

--- a/src/fmdb/FMDatabaseAdditions.h
+++ b/src/fmdb/FMDatabaseAdditions.h
@@ -11,11 +11,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** Category of additions for `<FMDatabase>` class.
+/** Category of additions for @c FMDatabase  class.
  
- ### See also
+ See also
 
- - `<FMDatabase>`
+ - @c FMDatabase 
  */
 
 @interface FMDatabase (FMDatabaseAdditions)
@@ -24,24 +24,22 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Return results of SQL to variable
 ///----------------------------------------
 
-/** Return `int` value for query
+/** Return @c int  value for query
  
- @param query The SQL query to be performed. 
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
- @return `int` value.
+ @return @c int  value.
  
  @note This is not available from Swift.
  */
 
 - (int)intForQuery:(NSString*)query, ...;
 
-/** Return `long` value for query
+/** Return @c long  value for query
 
- @param query The SQL query to be performed.
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
- @return `long` value.
+ @return @c long  value.
  
  @note This is not available from Swift.
  */
@@ -50,8 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Return `BOOL` value for query
 
- @param query The SQL query to be performed.
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `BOOL` value.
  
@@ -62,8 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Return `double` value for query
 
- @param query The SQL query to be performed.
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
  @return `double` value.
  
@@ -72,36 +68,33 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (double)doubleForQuery:(NSString*)query, ...;
 
-/** Return `NSString` value for query
+/** Return @c NSString  value for query
 
- @param query The SQL query to be performed.
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
- @return `NSString` value.
+ @return @c NSString  value.
  
  @note This is not available from Swift.
  */
 
 - (NSString * _Nullable)stringForQuery:(NSString*)query, ...;
 
-/** Return `NSData` value for query
+/** Return @c NSData  value for query
 
- @param query The SQL query to be performed.
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
- @return `NSData` value.
+ @return @c NSData  value.
  
  @note This is not available from Swift.
  */
 
 - (NSData * _Nullable)dataForQuery:(NSString*)query, ...;
 
-/** Return `NSDate` value for query
+/** Return @c NSDate  value for query
 
- @param query The SQL query to be performed.
- @param ... A list of parameters that will be bound to the `?` placeholders in the SQL query.
+ @param query The SQL query to be performed, followed by a list of parameters that will be bound to the `?` placeholders in the SQL query.
 
- @return `NSDate` value.
+ @return @c NSDate  value.
  
  @note This is not available from Swift.
  */
@@ -122,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param tableName The name of the table being looked for.
 
- @return `YES` if table found; `NO` if not found.
+ @return @c YES if table found; @c NO if not found.
  */
 
 - (BOOL)tableExists:(NSString*)tableName;
@@ -137,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
  - `rootpage` - The page number of the root b-tree page for tables and indices
  - `sql` - The SQL that created the entity
 
- @return `FMResultSet` of schema; `nil` on error.
+ @return `FMResultSet` of schema; @c nil  on error.
  
  @see [SQLite File Format](https://sqlite.org/fileformat.html)
  */
@@ -161,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param tableName The name of the table for whom the schema will be returned.
  
- @return `FMResultSet` of schema; `nil` on error.
+ @return `FMResultSet` of schema; @c nil  on error.
  
  @see [table_info](https://sqlite.org/pragma.html#pragma_table_info)
  */
@@ -174,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param tableName The name of the table.
  
- @return `YES` if column exists in table in question; `NO` otherwise.
+ @return @c YES if column exists in table in question; @c NO otherwise.
  */
 
 - (BOOL)columnExists:(NSString*)columnName inTableWithName:(NSString*)tableName;
@@ -185,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param tableName The name of the table.
 
- @return `YES` if column exists in table in question; `NO` otherwise.
+ @return @c YES if column exists in table in question; @c NO otherwise.
  
  @see columnExists:inTableWithName:
  
@@ -201,9 +194,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param sql The SQL statement being validated.
  
- @param error This is a pointer to a `NSError` object that will receive the autoreleased `NSError` object if there was any error. If this is `nil`, no `NSError` result will be returned.
+ @param error This is a pointer to a @c NSError  object that will receive the autoreleased @c NSError  object if there was any error. If this is @c nil , no @c NSError  result will be returned.
  
- @return `YES` if validation succeeded without incident; `NO` otherwise.
+ @return @c YES if validation succeeded without incident; @c NO otherwise.
  
  */
 

--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -12,16 +12,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class FMDatabase;
 
-/** Pool of `<FMDatabase>` objects.
+/** Pool of @c FMDatabase  objects.
 
- ### See also
+ See also
  
- - `<FMDatabaseQueue>`
- - `<FMDatabase>`
+ - @c FMDatabaseQueue 
+ - @c FMDatabase 
 
- @warning Before using `FMDatabasePool`, please consider using `<FMDatabaseQueue>` instead.
+ @warning Before using @c FMDatabasePool , please consider using @c FMDatabaseQueue  instead.
 
- If you really really really know what you're doing and `FMDatabasePool` is what
+ If you really really really know what you're doing and @c FMDatabasePool  is what
  you really really need (ie, you're using a read only database), OK you can use
  it.  But just be careful not to deadlock!
 
@@ -61,16 +61,16 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param aPath The file path of the database.
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 + (instancetype)databasePoolWithPath:(NSString * _Nullable)aPath;
 
 /** Create pool using file URL.
  
- @param url The file `NSURL` of the database.
+ @param url The file @c NSURL  of the database.
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 + (instancetype)databasePoolWithURL:(NSURL * _Nullable)url;
@@ -80,17 +80,17 @@ NS_ASSUME_NONNULL_BEGIN
  @param aPath The file path of the database.
  @param openFlags Flags passed to the openWithFlags method of the database.
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 + (instancetype)databasePoolWithPath:(NSString * _Nullable)aPath flags:(int)openFlags;
 
 /** Create pool using file URL and specified flags
  
- @param url The file `NSURL` of the database.
+ @param url The file @c NSURL  of the database.
  @param openFlags Flags passed to the openWithFlags method of the database.
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 + (instancetype)databasePoolWithURL:(NSURL * _Nullable)url flags:(int)openFlags;
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param aPath The file path of the database.
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 - (instancetype)initWithPath:(NSString * _Nullable)aPath;
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param url The file `NSURL of the database.
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 - (instancetype)initWithURL:(NSURL * _Nullable)url;
@@ -118,17 +118,17 @@ NS_ASSUME_NONNULL_BEGIN
  @param aPath The file path of the database.
  @param openFlags Flags passed to the openWithFlags method of the database
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 - (instancetype)initWithPath:(NSString * _Nullable)aPath flags:(int)openFlags;
 
 /** Create pool using file URL and specified flags.
  
- @param url The file `NSURL` of the database.
+ @param url The file @c NSURL  of the database.
  @param openFlags Flags passed to the openWithFlags method of the database
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 - (instancetype)initWithURL:(NSURL * _Nullable)url flags:(int)openFlags;
@@ -139,18 +139,18 @@ NS_ASSUME_NONNULL_BEGIN
  @param openFlags Flags passed to the openWithFlags method of the database
  @param vfsName The name of a custom virtual file system
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 - (instancetype)initWithPath:(NSString * _Nullable)aPath flags:(int)openFlags vfs:(NSString * _Nullable)vfsName;
 
 /** Create pool using file URL and specified flags.
  
- @param url The file `NSURL` of the database.
+ @param url The file @c NSURL  of the database.
  @param openFlags Flags passed to the openWithFlags method of the database
  @param vfsName The name of a custom virtual file system
  
- @return The `FMDatabasePool` object. `nil` on error.
+ @return The @c FMDatabasePool  object. @c nil  on error.
  */
 
 - (instancetype)initWithURL:(NSURL * _Nullable)url flags:(int)openFlags vfs:(NSString * _Nullable)vfsName;
@@ -193,14 +193,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Synchronously perform database operations in pool.
 
- @param block The code to be run on the `FMDatabasePool` pool.
+ @param block The code to be run on the @c FMDatabasePool  pool.
  */
 
 - (void)inDatabase:(__attribute__((noescape)) void (^)(FMDatabase *db))block;
 
 /** Synchronously perform database operations in pool using transaction.
  
- @param block The code to be run on the `FMDatabasePool` pool.
+ @param block The code to be run on the @c FMDatabasePool  pool.
  
  @warning   Unlike SQLite's `BEGIN TRANSACTION`, this method currently performs
             an exclusive transaction, not a deferred transaction. This behavior
@@ -215,32 +215,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Synchronously perform database operations in pool using exclusive transaction.
  
- @param block The code to be run on the `FMDatabasePool` pool.
+ @param block The code to be run on the @c FMDatabasePool  pool.
  */
 
 - (void)inExclusiveTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations in pool using deferred transaction.
 
- @param block The code to be run on the `FMDatabasePool` pool.
+ @param block The code to be run on the @c FMDatabasePool  pool.
  */
 
 - (void)inDeferredTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using immediate transactions.
 
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  */
 
 - (void)inImmediateTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations in pool using save point.
 
- @param block The code to be run on the `FMDatabasePool` pool.
+ @param block The code to be run on the @c FMDatabasePool  pool.
  
- @return `NSError` object if error; `nil` if successful.
+ @return @c NSError  object if error; @c nil  if successful.
 
- @warning You can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock. If you need to nest, use `<[FMDatabase startSavePointWithName:error:]>` instead.
+ @warning You can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock. If you need to nest, use @c startSavePointWithName:error:  instead.
 */
 
 - (NSError * _Nullable)inSavePoint:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
@@ -257,10 +257,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Asks the delegate whether database should be added to the pool. 
  
- @param pool     The `FMDatabasePool` object.
- @param database The `FMDatabase` object.
+ @param pool     The @c FMDatabasePool  object.
+ @param database The @c FMDatabase  object.
  
- @return `YES` if it should add database to pool; `NO` if not.
+ @return @c YES if it should add database to pool; @c NO if not.
  
  */
 
@@ -268,8 +268,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Tells the delegate that database was added to the pool.
  
- @param pool     The `FMDatabasePool` object.
- @param database The `FMDatabase` object.
+ @param pool     The @c FMDatabasePool  object.
+ @param database The @c FMDatabase  object.
 
  */
 

--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -11,57 +11,63 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** To perform queries and updates on multiple threads, you'll want to use `FMDatabaseQueue`.
+/** To perform queries and updates on multiple threads, you'll want to use @c FMDatabaseQueue .
 
- Using a single instance of `<FMDatabase>` from multiple threads at once is a bad idea.  It has always been OK to make a `<FMDatabase>` object *per thread*.  Just don't share a single instance across threads, and definitely not across multiple threads at the same time.
+ Using a single instance of @c FMDatabase from multiple threads at once is a bad idea.  It has always been OK to make a @c FMDatabase  object *per thread*.  Just don't share a single instance across threads, and definitely not across multiple threads at the same time.
 
- Instead, use `FMDatabaseQueue`. Here's how to use it:
+ Instead, use @c FMDatabaseQueue . Here's how to use it:
 
  First, make your queue.
 
-    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:aPath];
+@code
+FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:aPath];
+@endcode
 
  Then use it like so:
 
-    [queue inDatabase:^(FMDatabase *db) {
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:1]];
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:2]];
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:3]];
+@code
+[queue inDatabase:^(FMDatabase *db) {
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:1]];
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:2]];
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:3]];
 
-        FMResultSet *rs = [db executeQuery:@"select * from foo"];
-        while ([rs next]) {
-            //…
-        }
-    }];
+    FMResultSet *rs = [db executeQuery:@"select * from foo"];
+    while ([rs next]) {
+        //…
+    }
+}];
+@endcode
 
  An easy way to wrap things up in a transaction can be done like this:
 
-    [queue inTransaction:^(FMDatabase *db, BOOL *rollback) {
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:1]];
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:2]];
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:3]];
+@code
+[queue inTransaction:^(FMDatabase *db, BOOL *rollback) {
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:1]];
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:2]];
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:3]];
 
-        if (whoopsSomethingWrongHappened) {
-            *rollback = YES;
-            return;
-        }
-        // etc…
-        [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:4]];
-    }];
+    // if (whoopsSomethingWrongHappened) {
+    //     *rollback = YES;
+    //     return;
+    // }
 
- `FMDatabaseQueue` will run the blocks on a serialized queue (hence the name of the class).  So if you call `FMDatabaseQueue`'s methods from multiple threads at the same time, they will be executed in the order they are received.  This way queries and updates won't step on each other's toes, and every one is happy.
+    // etc…
+    [db executeUpdate:@"INSERT INTO myTable VALUES (?)", [NSNumber numberWithInt:4]];
+}];
+@endcode
 
- ### See also
+ @c FMDatabaseQueue will run the blocks on a serialized queue (hence the name of the class).  So if you call @c FMDatabaseQueue 's methods from multiple threads at the same time, they will be executed in the order they are received.  This way queries and updates won't step on each other's toes, and every one is happy.
 
- - `<FMDatabase>`
-
- @warning Do not instantiate a single `<FMDatabase>` object and use it across multiple threads. Use `FMDatabaseQueue` instead.
+ @warning Do not instantiate a single @c FMDatabase  object and use it across multiple threads. Use @c FMDatabaseQueue  instead.
  
- @warning The calls to `FMDatabaseQueue`'s methods are blocking.  So even though you are passing along blocks, they will **not** be run on another thread.
+ @warning The calls to @c FMDatabaseQueue 's methods are blocking.  So even though you are passing along blocks, they will **not** be run on another thread.
+
+ @sa FMDatabase
 
  */
 
 @interface FMDatabaseQueue : NSObject
+
 /** Path of database */
 
 @property (atomic, retain, nullable) NSString *path;
@@ -82,16 +88,16 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param aPath The file path of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 + (nullable instancetype)databaseQueueWithPath:(NSString * _Nullable)aPath;
 
 /** Create queue using file URL.
  
- @param url The file `NSURL` of the database.
+ @param url The file @c NSURL  of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 + (nullable instancetype)databaseQueueWithURL:(NSURL * _Nullable)url;
@@ -101,16 +107,16 @@ NS_ASSUME_NONNULL_BEGIN
  @param aPath The file path of the database.
  @param openFlags Flags passed to the openWithFlags method of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 + (nullable instancetype)databaseQueueWithPath:(NSString * _Nullable)aPath flags:(int)openFlags;
 
 /** Create queue using file URL and specified flags.
  
- @param url The file `NSURL` of the database.
+ @param url The file @c NSURL  of the database.
  @param openFlags Flags passed to the openWithFlags method of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 + (nullable instancetype)databaseQueueWithURL:(NSURL * _Nullable)url flags:(int)openFlags;
 
@@ -118,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param aPath The file path of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 - (nullable instancetype)initWithPath:(NSString * _Nullable)aPath;
@@ -127,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param url The file `NSURL of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 - (nullable instancetype)initWithURL:(NSURL * _Nullable)url;
@@ -137,7 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param aPath The file path of the database.
  @param openFlags Flags passed to the openWithFlags method of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 - (nullable instancetype)initWithPath:(NSString * _Nullable)aPath flags:(int)openFlags;
@@ -147,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param url The file path of the database.
  @param openFlags Flags passed to the openWithFlags method of the database.
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 - (nullable instancetype)initWithURL:(NSURL * _Nullable)url flags:(int)openFlags;
@@ -158,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param openFlags Flags passed to the openWithFlags method of the database
  @param vfsName The name of a custom virtual file system
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 - (nullable instancetype)initWithPath:(NSString * _Nullable)aPath flags:(int)openFlags vfs:(NSString * _Nullable)vfsName;
@@ -169,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param openFlags Flags passed to the openWithFlags method of the database
  @param vfsName The name of a custom virtual file system
  
- @return The `FMDatabaseQueue` object. `nil` on error.
+ @return The @c FMDatabaseQueue  object. @c nil  on error.
  */
 
 - (nullable instancetype)initWithURL:(NSURL * _Nullable)url flags:(int)openFlags vfs:(NSString * _Nullable)vfsName;
@@ -197,14 +203,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Synchronously perform database operations on queue.
  
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  */
 
 - (void)inDatabase:(__attribute__((noescape)) void (^)(FMDatabase *db))block;
 
 /** Synchronously perform database operations on queue, using transactions.
 
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  
  @warning    Unlike SQLite's `BEGIN TRANSACTION`, this method currently performs
              an exclusive transaction, not a deferred transaction. This behavior
@@ -220,21 +226,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Synchronously perform database operations on queue, using deferred transactions.
  
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  */
 
 - (void)inDeferredTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using exclusive transactions.
  
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  */
 
 - (void)inExclusiveTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
 
 /** Synchronously perform database operations on queue, using immediate transactions.
 
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  */
 
 - (void)inImmediateTransaction:(__attribute__((noescape)) void (^)(FMDatabase *db, BOOL *rollback))block;
@@ -245,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Synchronously perform database operations using save point.
 
- @param block The code to be run on the queue of `FMDatabaseQueue`
+ @param block The code to be run on the queue of @c FMDatabaseQueue 
  */
 
 // NOTE: you can not nest these, since calling it will pull another database out of the pool and you'll get a deadlock.

--- a/src/fmdb/FMResultSet.h
+++ b/src/fmdb/FMResultSet.h
@@ -17,11 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class FMDatabase;
 @class FMStatement;
 
-/** Represents the results of executing a query on an `<FMDatabase>`.
+/** Represents the results of executing a query on an @c FMDatabase .
  
- ### See also
+ See also
  
- - `<FMDatabase>`
+ - @c FMDatabase 
  */
 
 @interface FMResultSet : NSObject
@@ -48,17 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Creating and closing a result set
 ///------------------------------------
 
-/** Create result set from `<FMStatement>`
- 
- @param statement A `<FMStatement>` to be performed
- 
- @param aDB A `<FMDatabase>` to be used
- 
- @return A `FMResultSet` on success; `nil` on failure
- */
-
-+ (instancetype)resultSetWithStatement:(FMStatement *)statement usingParentDatabase:(FMDatabase*)aDB shouldAutoClose:(BOOL)shouldAutoClose;
-
 /** Close result set */
 
 - (void)close;
@@ -71,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  You must always invoke `next` or `nextWithError` before attempting to access the values returned in a query, even if you're only expecting one.
 
- @return `YES` if row successfully retrieved; `NO` if end of result set reached
+ @return @c YES if row successfully retrieved; @c NO if end of result set reached
  
  @see hasAnotherRow
  */
@@ -117,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see next
  
- @warning The `hasAnotherRow` method must follow a call to `<next>`. If the previous database interaction was something other than a call to `next`, then this method may return `NO`, whether there is another row of data or not.
+ @warning The `hasAnotherRow` method must follow a call to `<next>`. If the previous database interaction was something other than a call to `next`, then this method may return @c NO, whether there is another row of data or not.
  */
 
 - (BOOL)hasAnotherRow;
@@ -135,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Column index for column name
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return Zero-based index for column.
  */
@@ -146,16 +135,16 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param columnIdx Zero-based index for column.
 
- @return columnName `NSString` value of the name of the column.
+ @return columnName @c NSString  value of the name of the column.
  */
 
 - (NSString * _Nullable)columnNameForIndex:(int)columnIdx;
 
 /** Result set integer value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
- @return `int` value of the result set's column.
+ @return @c int  value of the result set's column.
  */
 
 - (int)intForColumn:(NSString*)columnName;
@@ -164,16 +153,16 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param columnIdx Zero-based index for column.
 
- @return `int` value of the result set's column.
+ @return @c int  value of the result set's column.
  */
 
 - (int)intForColumnIndex:(int)columnIdx;
 
-/** Result set `long` value for column.
+/** Result set @c long  value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
- @return `long` value of the result set's column.
+ @return @c long  value of the result set's column.
  */
 
 - (long)longForColumn:(NSString*)columnName;
@@ -182,14 +171,14 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param columnIdx Zero-based index for column.
 
- @return `long` value of the result set's column.
+ @return @c long  value of the result set's column.
  */
 
 - (long)longForColumnIndex:(int)columnIdx;
 
 /** Result set `long long int` value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return `long long int` value of the result set's column.
  */
@@ -207,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Result set `unsigned long long int` value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return `unsigned long long int` value of the result set's column.
  */
@@ -225,7 +214,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Result set `BOOL` value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return `BOOL` value of the result set's column.
  */
@@ -243,7 +232,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Result set `double` value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return `double` value of the result set's column.
  
@@ -261,9 +250,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (double)doubleForColumnIndex:(int)columnIdx;
 
-/** Result set `NSString` value for column.
+/** Result set @c NSString  value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return String value of the result set's column.
  
@@ -271,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString * _Nullable)stringForColumn:(NSString*)columnName;
 
-/** Result set `NSString` value for column.
+/** Result set @c NSString  value for column.
 
  @param columnIdx Zero-based index for column.
 
@@ -280,16 +269,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString * _Nullable)stringForColumnIndex:(int)columnIdx;
 
-/** Result set `NSDate` value for column.
+/** Result set @c NSDate  value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return Date value of the result set's column.
  */
 
 - (NSDate * _Nullable)dateForColumn:(NSString*)columnName;
 
-/** Result set `NSDate` value for column.
+/** Result set @c NSDate  value for column.
 
  @param columnIdx Zero-based index for column.
 
@@ -299,11 +288,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDate * _Nullable)dateForColumnIndex:(int)columnIdx;
 
-/** Result set `NSData` value for column.
+/** Result set @c NSData  value for column.
  
  This is useful when storing binary data in table (such as image or the like).
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return Data value of the result set's column.
  
@@ -311,7 +300,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSData * _Nullable)dataForColumn:(NSString*)columnName;
 
-/** Result set `NSData` value for column.
+/** Result set @c NSData  value for column.
 
  @param columnIdx Zero-based index for column.
 
@@ -322,7 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Result set `(const unsigned char *)` value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return `(const unsigned char *)` value of the result set's column.
  */
@@ -344,7 +333,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param columnName Name of the column.
 
- @return Either `NSNumber`, `NSString`, `NSData`, or `NSNull`. If the column was `NULL`, this returns `[NSNull null]` object.
+ @return Either @c NSNumber , @c NSString , @c NSData , or @c NSNull . If the column was @c NULL , this returns `[NSNull null]` object.
 
  @see objectForKeyedSubscript:
  */
@@ -357,7 +346,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param columnIdx Zero-based index for column.
 
- @return Either `NSNumber`, `NSString`, `NSData`, or `NSNull`. If the column was `NULL`, this returns `[NSNull null]` object.
+ @return Either @c NSNumber , @c NSString , @c NSData , or @c NSNull . If the column was @c NULL , this returns `[NSNull null]` object.
 
  @see objectAtIndexedSubscript:
  */
@@ -367,20 +356,26 @@ NS_ASSUME_NONNULL_BEGIN
 /** Result set object for column.
  
  This method allows the use of the "boxed" syntax supported in Modern Objective-C. For example, by defining this method, the following syntax is now supported:
- 
-    id result = rs[@"employee_name"];
- 
+
+@code
+id result = rs[@"employee_name"];
+@endcode
+
  This simplified syntax is equivalent to calling:
  
-    id result = [rs objectForKeyedSubscript:@"employee_name"];
- 
+@code
+id result = [rs objectForKeyedSubscript:@"employee_name"];
+@endcode
+
  which is, it turns out, equivalent to calling:
  
-    id result = [rs objectForColumnName:@"employee_name"];
+@code
+id result = [rs objectForColumnName:@"employee_name"];
+@endcode
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
- @return Either `NSNumber`, `NSString`, `NSData`, or `NSNull`. If the column was `NULL`, this returns `[NSNull null]` object.
+ @return Either @c NSNumber , @c NSString , @c NSData , or @c NSNull . If the column was @c NULL , this returns `[NSNull null]` object.
  */
 
 - (id _Nullable)objectForKeyedSubscript:(NSString *)columnName;
@@ -389,26 +384,32 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method allows the use of the "boxed" syntax supported in Modern Objective-C. For example, by defining this method, the following syntax is now supported:
 
-    id result = rs[0];
+@code
+id result = rs[0];
+@endcode
 
  This simplified syntax is equivalent to calling:
 
-    id result = [rs objectForKeyedSubscript:0];
+@code
+id result = [rs objectForKeyedSubscript:0];
+@endcode
 
  which is, it turns out, equivalent to calling:
 
-    id result = [rs objectForColumnName:0];
+@code
+id result = [rs objectForColumnName:0];
+@endcode
 
  @param columnIdx Zero-based index for column.
 
- @return Either `NSNumber`, `NSString`, `NSData`, or `NSNull`. If the column was `NULL`, this returns `[NSNull null]` object.
+ @return Either @c NSNumber , @c NSString , @c NSData , or @c NSNull . If the column was @c NULL , this returns `[NSNull null]` object.
  */
 
 - (id _Nullable)objectAtIndexedSubscript:(int)columnIdx;
 
-/** Result set `NSData` value for column.
+/** Result set @c NSData  value for column.
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
  @return Data value of the result set's column.
 
@@ -420,7 +421,7 @@ If you don't, you're going to be in a world of hurt when you try and use the dat
 
 - (NSData * _Nullable)dataNoCopyForColumn:(NSString *)columnName NS_RETURNS_NOT_RETAINED;
 
-/** Result set `NSData` value for column.
+/** Result set @c NSData  value for column.
 
  @param columnIdx Zero-based index for column.
 
@@ -434,20 +435,20 @@ If you don't, you're going to be in a world of hurt when you try and use the dat
 
 - (NSData * _Nullable)dataNoCopyForColumnIndex:(int)columnIdx NS_RETURNS_NOT_RETAINED;
 
-/** Is the column `NULL`?
+/** Is the column @c NULL ?
  
  @param columnIdx Zero-based index for column.
 
- @return `YES` if column is `NULL`; `NO` if not `NULL`.
+ @return @c YES if column is @c NULL ; @c NO if not @c NULL .
  */
 
 - (BOOL)columnIndexIsNull:(int)columnIdx;
 
-/** Is the column `NULL`?
+/** Is the column @c NULL ?
 
- @param columnName `NSString` value of the name of the column.
+ @param columnName @c NSString  value of the name of the column.
 
- @return `YES` if column is `NULL`; `NO` if not `NULL`.
+ @return @c YES if column is @c NULL ; @c NO if not @c NULL .
  */
 
 - (BOOL)columnIsNull:(NSString*)columnName;


### PR DESCRIPTION
I noticed that the inline documentation, which was tailored for appledoc, didn’t render well within Xcode. For example, the documentation for `FMDatabaseQueue` looked like:

<img width="1680" alt="Screen Shot 2020-05-08 at 3 51 11 PM (2)" src="https://user-images.githubusercontent.com/1530768/81455584-7f6ee880-9144-11ea-8597-f7288695057c.png">

With this PR, it is now rendered like so:

<img width="1680" alt="Screen Shot 2020-05-08 at 3 50 21 PM (2)" src="https://user-images.githubusercontent.com/1530768/81455617-93b2e580-9144-11ea-8411-f9dba89ee945.png">

Bottom line, I’ve wrapped code blocks with `@code`/`@endcode`, replaced back ticks with `@c` tags, etc. I’ve also fixed some problems (e.g. a `#pragma` between the comment and the `@interface` was preventing documentation from showing up; a private method that shouldn’t have been exposed has been hidden; etc.).

In full disclosure, I didn’t do much review of the content of the documentation, but focused largely on the formatting only. Also, this was a fairly cursory cleanup and I’m sure it’s not perfect, but it’s much better, IMHO.

Assuming you’re good with these fixes, I’d suggest rebuilding the gh-pages documentation, but rather than using [appledoc](https://github.com/tomaz/appledoc) (which doesn’t appear to have been updated in a very long time), I’ve found [jazzy](https://github.com/realm/jazzy) to be a little more up to date with modern auto-documenting conventions. I’ll do separate PR for that (if and when you approve this PR).