### PR TITLE
Update example code for FMResultSet

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -241,6 +241,7 @@ FMResultSet *s = [db executeQuery:@"SELECT COUNT(*) FROM myTable"];
 if ([s next]) {
     int totalCount = [s intForColumnIndex:0];
 }
+[s close];  //  If you cannot confirm whether the result set is exhausted, you will need to call the -close method on the FMResultSet for safety.
 ```
 
 `FMResultSet` has many methods to retrieve data in an appropriate format:


### PR DESCRIPTION
We recently discovered _sqlite3DbMallocRawNN crash, MACH_Exception EXC_BAD_ACCESS KERN_INVALID_ADDRESS fault_address:0x3037646236307474. 
And we find a commit: 7da3c812cdddd6f5da1df31e7751ef3e56dacd6b. This commit update documentation for FMResultSet.
I suggest to update example code for FMResultSet. If the user did not read the newest documentation, they can read example code and avoid making mistakes.