### PR TITLE
Fixed issue from [3e5efdf] (pull request #806) which broke cocoapods for iOS only projects

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
   s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => "#{s.version}" }
   s.requires_arc = true
+  s.ios.deployment_target  = '9.0'
   s.osx.deployment_target  = '10.11'
   s.default_subspec = 'standard'  
 


### PR DESCRIPTION
If specifying an OS X deployment ([3e5efdf]), an iOS one needs to be specified, too.