### PR TITLE
Add null check before sqlite3_step

### DIFF
--- a/src/fmdb/FMResultSet.m
+++ b/src/fmdb/FMResultSet.m
@@ -180,6 +180,17 @@
 }
 
 - (int)internalStepWithError:(NSError * _Nullable __autoreleasing *)outErr {
+    // Check for possible `nil _statement` to avoid a crash.
+    if (_statement == nil) {
+
+        if (outErr != nil) {
+            NSDictionary* errorMessage = [NSDictionary dictionaryWithObject:@"_statement should not be nil" forKey:NSLocalizedDescriptionKey];
+            *outErr = [NSError errorWithDomain:@"FMDatabase" code:SQLITE_MISUSE userInfo:errorMessage];
+        }
+
+        return SQLITE_MISUSE;
+    }
+
     int rc = sqlite3_step([_statement statement]);
     
     if (SQLITE_BUSY == rc || SQLITE_LOCKED == rc) {


### PR DESCRIPTION
Hello, I want to add a null check on `_statement` just before we add it in the sqlite3_step.

Our production app is getting a lot of crash's at this line `int rc = sqlite3_step([_statement statement]);`

It is random and I have no idea how to re-create this. 

I'm guessing it is some sort of race condition where the _statement is set to null in the `close()` method.

I just want to avoid a crash.

Let me know what you guys think.