### PR TITLE
Fix dangling reference warning on assign object property

### DIFF
--- a/src/fmdb/FMDatabasePool.h
+++ b/src/fmdb/FMDatabasePool.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Delegate object */
 
-@property (atomic, assign, nullable) id delegate;
+@property (atomic, unsafe_unretained, nullable) id delegate;
 
 /** Maximum number of databases to create */
 


### PR DESCRIPTION
[This doesn't change the behavior](https://clang.llvm.org/docs/AutomaticReferenceCounting.html#property-declarations), it just makes the behavior explicit and silences this compiler warning when using FMDB in a project that has the `-Wobjc-property-assign-on-object-type` warning flag:

> 'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained'

The alternative would have been to make this a weak property, but this would have been a behavior change, and after reading the discussion https://github.com/ccgus/fmdb/issues/522, I gather that this is something that shouldn't be done in FMDB without bumping the major version number.