### PR TITLE
Ups podspec min versions for modern xcode (xcode 14.3.x)

### DIFF
--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -7,9 +7,9 @@ Pod::Spec.new do |s|
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
   s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => "#{s.version}" }
   s.requires_arc = true
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
-  s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.watchos.deployment_target = '7.0'
   s.default_subspec = 'standard'
 
   # use the built-in library version of sqlite3


### PR DESCRIPTION
iOS min 11, macOS min 10.13, watchOS min 7.0.

Should fix: https://github.com/ccgus/fmdb/issues/844