### PR TITLE
[URGENT] Fix CocoaPods and Swift Package Manager Installation Methods

### DIFF
--- a/CHANGES_AND_TODO_LIST.txt
+++ b/CHANGES_AND_TODO_LIST.txt
@@ -3,6 +3,9 @@ Zip, nada, zilch.  Got any ideas?
 
 If you would like to contribute some code ... awesome!  I just ask that you make it conform to the coding conventions already set in here, and to add the necessary of tests for your new code to tests target.  And of course, the code should be of general use to more than just a couple of folks.  Send your patches to gus@flyingmeat.com.
 
+2024.05.29 Version 2.7.12
+    Fix Privacy Manifest resource bundling for CocoaPods and Swift Package Manager installation methods.
+
 2023.02.08 - 2023.05.23 Versions 2.7.9 - 2.7.11
     CocoaPods-related fixes and tweaks.
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,5 +47,6 @@ David Hart
 Mike Ash
 Julius Scott
 Justin Miller
+Troy Stump
 
 Aaaaannnd, Gus Mueller (that's me!)

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,60 +1,57 @@
 Pod::Spec.new do |s|
   s.name = 'FMDB'
-  s.version = '2.7.11'
+  s.version = '2.7.12'
   s.summary = 'A Cocoa / Objective-C wrapper around SQLite.'
   s.homepage = 'https://github.com/ccgus/fmdb'
   s.license = 'MIT'
   s.author = { 'August Mueller' => 'gus@flyingmeat.com' }
   s.source = { :git => 'https://github.com/ccgus/fmdb.git', :tag => "#{s.version}" }
   s.requires_arc = true
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.13'
   s.watchos.deployment_target = '7.0'
-  s.tvos.deployment_target = '11.0'
+  s.tvos.deployment_target = '12.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.default_subspec = 'standard'
 
-  # use the built-in library version of sqlite3
-  s.subspec 'standard' do |ss|
-    ss.library = 'sqlite3'
+  s.subspec 'Core' do |ss|
     ss.source_files = 'src/fmdb/FM*.{h,m}'
     ss.exclude_files = 'src/fmdb.m'
     ss.header_dir = 'fmdb'
+    ss.resource_bundles = { 'FMDB_Privacy' => 'privacy/PrivacyInfo.xcprivacy' }
+  end
+
+  # use the built-in library version of sqlite3
+  s.subspec 'standard' do |ss|
+    ss.dependency 'FMDB/Core'
+    ss.library = 'sqlite3'
   end
 
   # use the built-in library version of sqlite3 with custom FTS tokenizer source files
   s.subspec 'FTS' do |ss|
-    ss.source_files = 'src/extra/fts3/*.{h,m}'
     ss.dependency 'FMDB/standard'
+    ss.source_files = 'src/extra/fts3/*.{h,m}'
   end
-  
-  # Commenting these out (2024.2.26) to get CocoaPods upstream stuff working again.
+
   # build the latest stable version of sqlite3
-  #s.subspec 'standalone' do |ss|
-  #  ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE' }
-  #  ss.dependency 'sqlite3'
-  #  ss.source_files = 'src/fmdb/FM*.{h,m}'
-  #  ss.exclude_files = 'src/fmdb.m'
-  #  ss.header_dir = 'fmdb'
-  #end
+  s.subspec 'standalone' do |ss|
+    ss.dependency 'FMDB/Core'
+    ss.dependency 'sqlite3', '~> 3.46'
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE' }
+  end
 
   # build with FTS support and custom FTS tokenizer source files
-  #s.subspec 'standalone-fts' do |ss|
-  #  ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE' }
-  #  ss.source_files = 'src/fmdb/FM*.{h,m}', 'src/extra/fts3/*.{h,m}'
-  #  ss.exclude_files = 'src/fmdb.m'
-  #  ss.header_dir = 'fmdb'
-  #  ss.dependency 'sqlite3/fts'
-  #end
+  s.subspec 'standalone-fts' do |ss|
+    ss.dependency 'FMDB/Core'
+    ss.dependency 'sqlite3/fts', '~> 3.46'
+    ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DFMDB_SQLITE_STANDALONE' }
+    ss.source_files = 'src/extra/fts3/*.{h,m}'
+  end
 
   # use SQLCipher and enable -DSQLITE_HAS_CODEC flag
   s.subspec 'SQLCipher' do |ss|
-    ss.dependency 'SQLCipher', '~> 4.0'
-    ss.source_files = 'src/fmdb/FM*.{h,m}'
-    ss.exclude_files = 'src/fmdb.m'
-    ss.header_dir = 'fmdb'
-    ss.resource_bundles = {'SQLCipher' => ['privacy/PrivacyInfo.xcprivacy']}
+    ss.dependency 'FMDB/Core'
+    ss.dependency 'SQLCipher', '~> 4.6'
     ss.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DHAVE_USLEEP=1 -DSQLCIPHER_CRYPTO', 'HEADER_SEARCH_PATHS' => 'SQLCipher' }
   end
-  
-  s.resource_bundles = {'FMDB' => ['privacy/PrivacyInfo.xcprivacy']}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,6 +20,7 @@ let package = Package(
             name: "FMDB",
             dependencies: [],
             path: "src/fmdb",
+            resources: [.process("../../privacy/PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
     ]
 )

--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ Then, edit the `Podfile`, adding `FMDB`:
 
 ```ruby
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '12.0'
 
 target 'MyApp' do
     # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
@@ -78,7 +78,7 @@ Declare FMDB as a package dependency.
 .package(
     name: "FMDB", 
     url: "https://github.com/ccgus/fmdb", 
-    .upToNextMinor(from: "2.7.8")),
+    .upToNextMinor(from: "2.7.12")),
 ```
 
 Use FMDB in target dependencies

--- a/Tests/FMDatabaseTests.m
+++ b/Tests/FMDatabaseTests.m
@@ -1132,7 +1132,7 @@
  */
 
 - (void)testUserVersion {
-    NSComparisonResult result = [[FMDatabase FMDBUserVersion] compare:@"2.7.8" options:NSNumericSearch];
+    NSComparisonResult result = [[FMDatabase FMDBUserVersion] compare:@"2.7.12" options:NSNumericSearch];
     XCTAssertEqual(result, NSOrderedSame);
 }
 

--- a/src/fmdb/FMDatabase.h
+++ b/src/fmdb/FMDatabase.h
@@ -1123,7 +1123,7 @@ func executeUpdate(sql: String, values: [Any]?) throws -> Bool { }
 
 + (NSString*)sqliteLibVersion;
 
-/// The FMDB version number as a string in the form of @c "2.7.8" .
+/// The FMDB version number as a string in the form of @c "2.7.12" .
 ///
 /// If you want to compare version number strings, you can use NSNumericSearch option:
 ///

--- a/src/fmdb/FMDatabase.m
+++ b/src/fmdb/FMDatabase.m
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_END
 }
 
 + (NSString*)FMDBUserVersion {
-    return @"2.7.8";
+    return @"2.7.12";
 }
 
 + (SInt32)FMDBVersion {


### PR DESCRIPTION
### Background
After pushing the 2.7.11 release to CocoaPods trunk, the CocoaPods installation method is broken for people who use the following library subspec:
`FMDB/SQLCipher`

The issue is seen only when archiving an application for release, which fails because both the FMDB/SQLCipher subspec and SQLCipher dependency are including a Resource Bundle with the same name ("SQLCipher"). Below is the error output from xcodebuild:
`error: Multiple commands produce '.../IntermediateBuildFilesPath/UninstalledProducts/iphoneos/SQLCipher.bundle'
    note: Target 'FMDB-SQLCipher' (project 'Pods') has create directory command with output '.../IntermediateBuildFilesPath/UninstalledProducts/iphoneos/SQLCipher.bundle'
    note: Target 'SQLCipher-SQLCipher' (project 'Pods') has create directory command with output '.../IntermediateBuildFilesPath/UninstalledProducts/iphoneos/SQLCipher.bundle'`

### Purpose
The purpose of these changes is to fix CocoaPods and Swift Package Manager installation methods by correctly bundling the newly introduced Privacy Manifest resource file, while avoiding Resource Bundle name collisions.

NOTE: I've recently helped other popular libraries resolve similar issues, such as Pinterest's [PINCache](https://github.com/pinterest/PINCache/pull/327).

**This screenshot demonstrates successfully linting via CocoaPods, which includes the standalone subspecs that were temporarily disabled:**
<img width="1424" alt="FMDB - CocoaPods - Linting" src="https://github.com/ccgus/fmdb/assets/10544263/4b4eb4fe-b51c-47de-9f52-b21bbab566cf">

**This screenshot demonstrates successfully resolving the Privacy Manifest file via Swift Package Manager:**
<img width="1667" alt="FMDB - Swift Package Manager" src="https://github.com/ccgus/fmdb/assets/10544263/9962983b-cd10-4f09-af96-f61570dab377">

**This screenshot demonstrates successfully installing FMDB into my application (which can now be archived for release):**
<img width="336" alt="FMDB - CocoaPods - Installation" src="https://github.com/ccgus/fmdb/assets/10544263/b323c111-ab48-429b-a220-145080de9921">
*_screenshot was taken before I fixed a typo in the resource bundle name_